### PR TITLE
﻿fix(ci): checkout main branch in create-tag to avoid workflow permis…

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -88,6 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.PAT }}
           persist-credentials: true


### PR DESCRIPTION
…sion error

Use ref: main in checkout to ensure we are tagging the main branch HEAD, not a commit that contains workflow file changes.

This fixes the error: refusing to allow a GitHub App to create or update workflow without workflows permission