### PR TITLE
feat: 新增用戶戰績統計功能與錯誤頁面重新設計

### DIFF
--- a/src/lib/components/ui/FooterDecoration.svelte
+++ b/src/lib/components/ui/FooterDecoration.svelte
@@ -1,168 +1,53 @@
 <script lang="ts">
-	export let text: string;
+	export let text: string = '傳承千年智慧，品鑑古董真偽';
 </script>
 
 <div class="footer-decoration">
-	<div class="footer-line left"></div>
-	<div class="footer-content">
-		<div class="footer-icon">
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="20"
-				height="20"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-			>
-				<circle cx="12" cy="12" r="10"></circle>
-				<line x1="12" y1="8" x2="12" y2="12"></line>
-				<line x1="12" y1="16" x2="12.01" y2="16"></line>
-			</svg>
-		</div>
-		<span class="footer-text">{text}</span>
-		<div class="footer-icon">
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="20"
-				height="20"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-			>
-				<circle cx="12" cy="12" r="10"></circle>
-				<line x1="12" y1="8" x2="12" y2="12"></line>
-				<line x1="12" y1="16" x2="12.01" y2="16"></line>
-			</svg>
-		</div>
-	</div>
-	<div class="footer-line right"></div>
+	<div class="footer-line"></div>
+	<p class="footer-text">{text}</p>
+	<div class="footer-line"></div>
 </div>
 
 <style>
 	.footer-decoration {
+		margin-top: 2rem;
+		color: hsl(var(--muted-foreground));
+		font-size: 1.1rem;
+		font-style: italic;
+		opacity: 0.8;
 		display: flex;
 		align-items: center;
-		justify-content: center;
-		gap: 1.5rem;
+		gap: 1rem;
 		width: 100%;
-		max-width: 700px;
-		padding: 2rem 1rem;
-		margin-top: 2rem;
+		max-width: 600px;
 	}
 
 	.footer-line {
 		flex: 1;
-		height: 2px;
-		position: relative;
-		overflow: hidden;
-	}
-
-	.footer-line::before {
-		content: '';
-		position: absolute;
-		top: 0;
-		width: 100%;
-		height: 100%;
-		background: linear-gradient(to right, transparent, rgba(212, 175, 55, 0.6), transparent);
-		animation: shimmer 3s ease-in-out infinite;
-	}
-
-	.footer-line.left::before {
-		animation-delay: 0s;
-	}
-
-	.footer-line.right::before {
-		animation-delay: 1.5s;
-	}
-
-	@keyframes shimmer {
-		0%,
-		100% {
-			opacity: 0.3;
-		}
-		50% {
-			opacity: 1;
-		}
-	}
-
-	.footer-content {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		padding: 0.75rem 1.5rem;
-		background: linear-gradient(135deg, rgba(212, 175, 55, 0.15), rgba(212, 175, 55, 0.08));
-		border: 1px solid rgba(212, 175, 55, 0.3);
-		border-radius: calc(var(--radius) * 2);
-		backdrop-filter: blur(10px);
-		box-shadow:
-			0 4px 12px rgba(0, 0, 0, 0.2),
-			inset 0 1px 0 rgba(255, 255, 255, 0.1);
-	}
-
-	.footer-icon {
-		color: rgba(212, 175, 55, 0.8);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		animation: pulse-icon 2s ease-in-out infinite;
-	}
-
-	@keyframes pulse-icon {
-		0%,
-		100% {
-			opacity: 0.6;
-			transform: scale(1);
-		}
-		50% {
-			opacity: 1;
-			transform: scale(1.1);
-		}
+		height: 1px;
+		background: linear-gradient(
+			to right,
+			transparent,
+			hsl(var(--muted-foreground) / 0.3),
+			transparent
+		);
 	}
 
 	.footer-text {
-		color: hsl(var(--foreground));
+		color: hsl(var(--muted-foreground));
+		font-size: 1.1rem;
 		font-style: italic;
-		font-size: 1rem;
+		margin: 0;
 		white-space: nowrap;
-		font-weight: 600;
-		text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-		letter-spacing: 0.02em;
 	}
 
 	@media (max-width: 768px) {
 		.footer-decoration {
-			gap: 1rem;
-			padding: 1.5rem 0.5rem;
-			margin-top: 1.5rem;
-		}
-
-		.footer-content {
-			padding: 0.625rem 1.25rem;
+			font-size: 1rem;
 		}
 
 		.footer-text {
-			font-size: 0.9rem;
-		}
-
-		.footer-icon svg {
-			width: 16px;
-			height: 16px;
-		}
-	}
-
-	@media (max-width: 480px) {
-		.footer-line {
-			display: none;
-		}
-
-		.footer-decoration {
-			gap: 0;
+			font-size: 1rem;
 		}
 	}
 </style>

--- a/src/lib/components/ui/UserArea.svelte
+++ b/src/lib/components/ui/UserArea.svelte
@@ -9,9 +9,11 @@
 		| undefined = undefined;
 
 	import EditProfileModal from './EditProfileModal.svelte';
+	import UserStatsModal from './UserStatsModal.svelte';
 
 	let isDropdownOpen = false;
 	let isEditModalOpen = false;
+	let isStatsModalOpen = false;
 
 	// 從 email 或 nickname 生成頭像文字（取第一個字符）
 	$: avatarText = (nickname || email || '?').charAt(0).toUpperCase();
@@ -35,6 +37,11 @@
 
 	function openEditModal() {
 		isEditModalOpen = true;
+		closeDropdown();
+	}
+
+	function openStatsModal() {
+		isStatsModalOpen = true;
 		closeDropdown();
 	}
 
@@ -105,6 +112,23 @@
 				</svg>
 				編輯個人資料
 			</button>
+			<button class="dropdown-item" on:click={openStatsModal}>
+				<svg
+					width="18"
+					height="18"
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				>
+					<path d="M18 20V10"></path>
+					<path d="M12 20V4"></path>
+					<path d="M6 20v-6"></path>
+				</svg>
+				歷史戰績
+			</button>
 			<div class="dropdown-divider"></div>
 			<button class="dropdown-item logout" on:click={onLogout}>
 				<svg
@@ -135,6 +159,8 @@
 	on:save={handleProfileSave}
 	on:close={() => (isEditModalOpen = false)}
 />
+
+<UserStatsModal bind:isOpen={isStatsModalOpen} onClose={() => (isStatsModalOpen = false)} />
 
 <style>
 	.user-area {

--- a/src/lib/components/ui/UserStatsModal.svelte
+++ b/src/lib/components/ui/UserStatsModal.svelte
@@ -1,0 +1,717 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+
+	export let isOpen: boolean = false;
+	export let onClose: () => void;
+
+	interface UserStats {
+		totalGames: number;
+		totalWins: number;
+		winRate: number;
+		xuYuanWins: number;
+		laoChaoFengWins: number;
+		roleStats: Array<{ name: string; count: number }>;
+		recentGames: Array<{
+			gameId: string;
+			roleName: string;
+			camp: string;
+			result: string;
+			score: number;
+			finishedAt: string | null;
+		}>;
+	}
+
+	let stats: UserStats | null = null;
+	let isLoading = true;
+	let error = '';
+	let portalTarget: HTMLElement | null = null;
+
+	async function loadStats() {
+		isLoading = true;
+		error = '';
+
+		try {
+			const response = await fetch('/api/user/stats', {
+				credentials: 'include'
+			});
+
+			if (response.ok) {
+				stats = await response.json();
+			} else {
+				error = '無法載入戰績資料';
+			}
+		} catch (err) {
+			console.error('載入戰績失敗:', err);
+			error = '載入戰績時發生錯誤';
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	onMount(() => {
+		// 創建 portal 容器（未使用，但保留供未來擴展）
+		portalTarget = document.createElement('div');
+		portalTarget.id = 'user-stats-modal-portal';
+		document.body.appendChild(portalTarget);
+
+		if (isOpen) {
+			loadStats();
+		}
+
+		return () => {
+			if (portalTarget && document.body.contains(portalTarget)) {
+				document.body.removeChild(portalTarget);
+			}
+			// 清理時恢復滾動
+			document.body.style.overflow = '';
+		};
+	});
+
+	onDestroy(() => {
+		if (portalTarget && document.body.contains(portalTarget)) {
+			document.body.removeChild(portalTarget);
+		}
+		// 確保恢復滾動
+		if (typeof document !== 'undefined') {
+			document.body.style.overflow = '';
+		}
+	});
+
+	$: if (typeof document !== 'undefined') {
+		if (isOpen) {
+			loadStats();
+			// 防止背景滾動
+			document.body.style.overflow = 'hidden';
+		} else {
+			// 恢復背景滾動
+			document.body.style.overflow = '';
+		}
+	}
+
+	function formatDate(dateString: string | null): string {
+		if (!dateString) return '未知';
+		const date = new Date(dateString);
+		return date.toLocaleDateString('zh-TW', {
+			year: 'numeric',
+			month: '2-digit',
+			day: '2-digit',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+
+	function handleBackdropClick(event: MouseEvent) {
+		if (event.target === event.currentTarget) {
+			onClose();
+		}
+	}
+</script>
+
+{#if isOpen}
+	<!-- svelte-ignore a11y-click-events-have-key-events -->
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<div class="modal-backdrop" on:click={handleBackdropClick}>
+		<div class="modal-container">
+			<!-- 標題 -->
+			<div class="modal-header">
+				<h2>戰績統計</h2>
+				<button class="close-btn" on:click={onClose} aria-label="關閉">
+					<svg
+						width="20"
+						height="20"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+					>
+						<line x1="18" y1="6" x2="6" y2="18"></line>
+						<line x1="6" y1="6" x2="18" y2="18"></line>
+					</svg>
+				</button>
+			</div>
+
+			<!-- 內容 -->
+			<div class="modal-content">
+				{#if isLoading}
+					<div class="loading">
+						<div class="spinner"></div>
+						<p>載入中...</p>
+					</div>
+				{:else if error}
+					<div class="error-message">
+						<p>{error}</p>
+					</div>
+				{:else if stats}
+					<!-- 總覽統計 -->
+					<div class="stats-grid">
+						<div class="stat-card">
+							<div class="stat-label">總場次</div>
+							<div class="stat-value">{stats.totalGames}</div>
+						</div>
+						<div class="stat-card">
+							<div class="stat-label">勝場</div>
+							<div class="stat-value highlight">{stats.totalWins}</div>
+						</div>
+						<div class="stat-card">
+							<div class="stat-label">勝率</div>
+							<div class="stat-value highlight">{stats.winRate}%</div>
+						</div>
+					</div>
+
+					<!-- 陣營統計 -->
+					<div class="section">
+						<h3>陣營戰績</h3>
+						<div class="camp-grid">
+							<div class="camp-item xuyuan">
+								<div class="camp-name">許愿陣營</div>
+								<div class="camp-value">{stats.xuYuanWins} 勝</div>
+							</div>
+							<div class="camp-item laochaofeng">
+								<div class="camp-name">老朝奉陣營</div>
+								<div class="camp-value">{stats.laoChaoFengWins} 勝</div>
+							</div>
+						</div>
+					</div>
+
+					<!-- 角色統計 -->
+					<div class="section">
+						<h3>角色使用</h3>
+						{#if stats.roleStats.length > 0}
+							<div class="role-list">
+								{#each stats.roleStats as role (role.name)}
+									<div class="role-row">
+										<span class="role-name">{role.name}</span>
+										<div class="role-bar-bg">
+											<div
+												class="role-bar"
+												style="width: {(role.count / stats.totalGames) * 100}%"
+											></div>
+										</div>
+										<span class="role-count">{role.count}</span>
+									</div>
+								{/each}
+							</div>
+						{:else}
+							<div class="empty">尚無角色資料</div>
+						{/if}
+					</div>
+
+					<!-- 近期記錄 -->
+					<div class="section">
+						<h3>近期戰績</h3>
+						{#if stats.recentGames.length > 0}
+							<div class="game-list">
+								{#each stats.recentGames as game (game.gameId)}
+									<div class="game-item" class:win={game.result === '勝利'}>
+										<div class="game-result">
+											<span class="result-badge" class:victory={game.result === '勝利'}>
+												{game.result === '勝利' ? '勝' : '敗'}
+											</span>
+										</div>
+										<div class="game-details">
+											<div class="game-role">{game.roleName}</div>
+											<div class="game-meta">
+												<span class="game-camp">{game.camp}</span>
+												<span class="game-divider">•</span>
+												<span class="game-score">{game.score} 分</span>
+											</div>
+										</div>
+										<div class="game-date">{formatDate(game.finishedAt)}</div>
+									</div>
+								{/each}
+							</div>
+						{:else}
+							<div class="empty">
+								<p>尚無完成的遊戲記錄</p>
+							</div>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.modal-backdrop {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background: rgba(0, 0, 0, 0.5);
+		backdrop-filter: blur(4px);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 9999;
+		animation: fadeIn 0.15s ease;
+		padding: 1rem;
+	}
+
+	@keyframes fadeIn {
+		from {
+			opacity: 0;
+		}
+	}
+
+	.modal-container {
+		background: hsl(var(--background));
+		border: 1px solid hsl(var(--border));
+		border-radius: 12px;
+		width: 100%;
+		max-width: 700px;
+		max-height: 90vh;
+		display: flex;
+		flex-direction: column;
+		box-shadow:
+			0 20px 25px -5px rgba(0, 0, 0, 0.1),
+			0 10px 10px -5px rgba(0, 0, 0, 0.04);
+		animation: slideUp 0.2s ease;
+	}
+
+	@keyframes slideUp {
+		from {
+			opacity: 0;
+			transform: translateY(10px);
+		}
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 1.25rem 1.5rem;
+		border-bottom: 1px solid hsl(var(--border));
+	}
+
+	h2 {
+		margin: 0;
+		font-size: 1.25rem;
+		font-weight: 600;
+		color: hsl(var(--foreground));
+	}
+
+	.close-btn {
+		background: transparent;
+		border: none;
+		color: hsl(var(--muted-foreground));
+		cursor: pointer;
+		padding: 0.5rem;
+		border-radius: 6px;
+		transition: all 0.15s;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.close-btn:hover {
+		background: hsl(var(--accent));
+		color: hsl(var(--accent-foreground));
+	}
+
+	.modal-content {
+		flex: 1;
+		overflow-y: auto;
+		padding: 1.5rem;
+	}
+
+	/* Loading */
+	.loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 4rem 2rem;
+		gap: 1rem;
+	}
+
+	.spinner {
+		width: 40px;
+		height: 40px;
+		border: 3px solid hsl(var(--border));
+		border-top-color: hsl(var(--primary));
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.loading p {
+		color: hsl(var(--muted-foreground));
+		font-size: 0.875rem;
+	}
+
+	/* Error */
+	.error-message {
+		padding: 3rem 2rem;
+		text-align: center;
+		color: hsl(var(--destructive));
+	}
+
+	/* Stats Grid */
+	.stats-grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 1rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.stat-card {
+		background: transparent;
+		border: 1px solid hsl(var(--border));
+		border-radius: 8px;
+		padding: 1.25rem;
+		text-align: center;
+	}
+
+	.stat-label {
+		font-size: 0.875rem;
+		color: hsl(var(--muted-foreground));
+		margin-bottom: 0.5rem;
+	}
+
+	.stat-value {
+		font-size: 2rem;
+		font-weight: 700;
+		color: hsl(var(--foreground));
+	}
+
+	.stat-value.highlight {
+		color: #22c55e;
+	}
+
+	/* Section */
+	.section {
+		margin-bottom: 1.5rem;
+	}
+
+	.section h3 {
+		font-size: 1rem;
+		font-weight: 600;
+		color: hsl(var(--foreground));
+		margin: 0 0 1rem 0;
+	}
+
+	/* Camp */
+	.camp-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1rem;
+	}
+
+	.camp-item {
+		background: transparent;
+		border: 2px solid hsl(var(--border));
+		border-radius: 8px;
+		padding: 1.25rem;
+		text-align: center;
+		transition: all 0.2s ease;
+	}
+
+	.camp-item:hover {
+		transform: translateY(-2px);
+	}
+
+	.camp-item.xuyuan {
+		border-color: #dc2626;
+		background: rgba(220, 38, 38, 0.05);
+	}
+
+	.camp-item.laochaofeng {
+		border-color: #6b7280;
+		background: rgba(107, 114, 128, 0.05);
+	}
+
+	.camp-name {
+		font-size: 0.875rem;
+		color: hsl(var(--muted-foreground));
+		margin-bottom: 0.5rem;
+		display: block;
+		font-weight: 500;
+	}
+
+	.camp-item.xuyuan .camp-name {
+		color: #dc2626;
+	}
+
+	.camp-item.laochaofeng .camp-name {
+		color: #6b7280;
+	}
+
+	.camp-value {
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: hsl(var(--foreground));
+	}
+
+	.camp-item.xuyuan .camp-value {
+		color: #dc2626;
+	}
+
+	.camp-item.laochaofeng .camp-value {
+		color: #4b5563;
+	}
+
+	/* Role List */
+	.role-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.role-row {
+		display: grid;
+		grid-template-columns: 100px 1fr 50px;
+		gap: 1rem;
+		align-items: center;
+		padding: 0.75rem;
+		background: transparent;
+		border: 1px solid hsl(var(--border));
+		border-radius: 6px;
+	}
+
+	.role-name {
+		font-weight: 500;
+		color: hsl(var(--foreground));
+	}
+
+	.role-bar-bg {
+		height: 8px;
+		background: hsl(var(--muted));
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	.role-bar {
+		height: 100%;
+		background: hsl(var(--primary));
+		border-radius: 4px;
+		transition: width 0.3s ease;
+	}
+
+	.role-count {
+		text-align: right;
+		font-size: 0.875rem;
+		color: hsl(var(--muted-foreground));
+		font-weight: 500;
+	}
+
+	/* Game List */
+	.game-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.game-item {
+		background: transparent;
+		border: 1px solid hsl(var(--border));
+		border-radius: 8px;
+		padding: 1rem;
+		display: grid;
+		grid-template-columns: 50px 1fr auto;
+		gap: 1rem;
+		align-items: center;
+		transition: all 0.15s;
+	}
+
+	.game-item:hover {
+		background: hsl(var(--accent) / 0.05);
+		border-color: hsl(var(--primary) / 0.5);
+	}
+
+	.game-result {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.result-badge {
+		width: 36px;
+		height: 36px;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 0.875rem;
+		font-weight: 700;
+		background: #ef4444;
+		color: white;
+		line-height: 1;
+		padding-top: 1px;
+	}
+
+	.result-badge.victory {
+		background: #22c55e;
+	}
+
+	.game-details {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.game-role {
+		font-weight: 600;
+		color: hsl(var(--foreground));
+	}
+
+	.game-meta {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+		font-size: 0.875rem;
+		color: hsl(var(--muted-foreground));
+	}
+
+	.game-divider {
+		color: hsl(var(--muted-foreground) / 0.5);
+	}
+
+	.game-date {
+		font-size: 0.75rem;
+		color: hsl(var(--muted-foreground));
+		text-align: right;
+	}
+
+	/* Empty */
+	.empty {
+		text-align: center;
+		padding: 2rem;
+		color: hsl(var(--muted-foreground));
+		font-size: 0.875rem;
+	}
+
+	/* Responsive */
+	@media (max-width: 768px) {
+		.modal-backdrop {
+			padding: 0;
+			align-items: flex-end;
+		}
+
+		.modal-container {
+			max-height: 85vh;
+			border-radius: 16px 16px 0 0;
+			margin: 0;
+		}
+
+		.modal-header {
+			padding: 1rem;
+		}
+
+		.modal-content {
+			padding: 1rem;
+		}
+
+		h2 {
+			font-size: 1.125rem;
+		}
+
+		.stats-grid {
+			grid-template-columns: 1fr;
+			gap: 0.75rem;
+			margin-bottom: 1rem;
+		}
+
+		.stat-card {
+			padding: 1rem;
+		}
+
+		.stat-value {
+			font-size: 1.75rem;
+		}
+
+		.section {
+			margin-bottom: 1rem;
+		}
+
+		.section h3 {
+			font-size: 0.9rem;
+			margin-bottom: 0.75rem;
+		}
+
+		.camp-grid {
+			grid-template-columns: 1fr;
+			gap: 0.75rem;
+		}
+
+		.camp-item {
+			padding: 1rem;
+		}
+
+		.camp-value {
+			font-size: 1.25rem;
+		}
+
+		.role-list {
+			gap: 0.5rem;
+		}
+
+		.role-row {
+			grid-template-columns: 80px 1fr 40px;
+			gap: 0.75rem;
+			padding: 0.625rem;
+		}
+
+		.role-name {
+			font-size: 0.875rem;
+		}
+
+		.role-bar-bg {
+			height: 6px;
+		}
+
+		.role-count {
+			font-size: 0.8rem;
+		}
+
+		.game-list {
+			gap: 0.5rem;
+		}
+
+		.game-item {
+			grid-template-columns: 40px 1fr;
+			gap: 0.75rem;
+			padding: 0.75rem;
+			align-items: center;
+		}
+
+		.game-result {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+		}
+
+		.result-badge {
+			width: 32px;
+			height: 32px;
+			font-size: 0.75rem;
+		}
+
+		.game-role {
+			font-size: 0.9rem;
+		}
+
+		.game-meta {
+			font-size: 0.8rem;
+			gap: 0.375rem;
+		}
+
+		.game-date {
+			grid-column: 2;
+			text-align: left;
+			font-size: 0.7rem;
+			margin-top: 0.25rem;
+		}
+
+		.empty {
+			padding: 1.5rem;
+			font-size: 0.8rem;
+		}
+	}
+</style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import MainTitle from '$lib/components/ui/MainTitle.svelte';
 	import ActionButton from '$lib/components/ui/ActionButton.svelte';
-	import FooterDecoration from '$lib/components/ui/FooterDecoration.svelte';
 
 	const getErrorTitle = (status: number) => {
 		switch (status) {
@@ -35,202 +33,195 @@
 	};
 </script>
 
-<div class="error-page">
-	<div class="error-container">
-		<div class="error-decoration">
-			<div class="ancient-pattern top-left"></div>
-			<div class="ancient-pattern top-right"></div>
-			<div class="ancient-pattern bottom-left"></div>
-			<div class="ancient-pattern bottom-right"></div>
-		</div>
+<div class="error-layout">
+	<div class="background-blur"></div>
 
-		<div class="error-content">
-			<div class="error-code">{$page.status}</div>
-
-			<MainTitle title={getErrorTitle($page.status)} subtitle={getErrorSubtitle($page.status)} />
-
-			<div class="action-area">
-				<ActionButton
-					onClick={goHome}
-					variant="primary"
-					title="返回首頁"
-					subtitle="回到古董局中局的起點"
-				/>
-			</div>
-		</div>
-
-		<FooterDecoration text="古董局中局" />
+	<div class="header">
+		<h1 class="main-title">古董局中局</h1>
+		<div class="gradient-line"></div>
 	</div>
+
+	<div class="error-card">
+		<div class="error-code">{$page.status}</div>
+
+		<h2 class="error-title">{getErrorTitle($page.status)}</h2>
+		<p class="error-subtitle">{getErrorSubtitle($page.status)}</p>
+
+		<div class="gradient-divider"></div>
+
+		<ActionButton
+			onClick={goHome}
+			variant="primary"
+			title="返回首頁"
+			subtitle="回到古董局中局的起點"
+		/>
+	</div>
+
+	<p class="footer-text">傳承千年智慧，品鑑古董真偽</p>
 </div>
 
 <style>
-	.error-page {
+	.error-layout {
+		background-color: hsl(var(--background));
+		position: relative;
 		min-height: 100vh;
 		width: 100%;
+		overflow-x: hidden;
 		display: flex;
 		flex-direction: column;
-		align-items: center;
 		justify-content: center;
+		align-items: center;
+		padding: 2rem 0;
+	}
+
+	.background-blur {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
 		background-image: url('/background.jpg');
 		background-size: cover;
 		background-position: center;
-		background-attachment: fixed;
-		position: relative;
-		padding: 2rem;
-	}
-
-	.error-page::before {
-		content: '';
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		background: radial-gradient(
-			circle at center,
-			hsl(var(--background) / 0.9),
-			hsl(var(--background) / 0.97)
-		);
+		background-repeat: no-repeat;
+		filter: blur(12px) brightness(0.7);
 		z-index: 0;
 	}
 
-	.error-container {
+	.header {
 		position: relative;
 		z-index: 1;
-		width: 100%;
-		max-width: 900px;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 3rem;
+		margin-bottom: 2rem;
 	}
 
-	.error-decoration {
-		position: absolute;
-		top: -40px;
-		left: -40px;
-		right: -40px;
-		bottom: -40px;
-		pointer-events: none;
-		z-index: -1;
+	.main-title {
+		color: hsl(var(--foreground));
+		font-size: 3.5rem;
+		font-weight: 400;
+		text-align: center;
+		margin: 0;
+		text-shadow: 0 4px 8px hsl(var(--background) / 0.8);
+		letter-spacing: 0.1em;
 	}
 
-	.ancient-pattern {
-		position: absolute;
-		width: 80px;
-		height: 80px;
-		border: 2px solid hsl(var(--primary) / 0.4);
-		transition: var(--transition-elegant);
+	.gradient-line {
+		width: 10rem;
+		height: 0.25rem;
+		background: linear-gradient(to right, hsl(var(--primary)), hsl(var(--secondary)));
+		margin: 1.25rem auto 0;
+		border-radius: 9999px;
 	}
 
-	.ancient-pattern::before {
-		content: '';
-		position: absolute;
-		width: 100%;
-		height: 100%;
-		border: 1px solid hsl(var(--secondary) / 0.3);
-		top: 8px;
-		left: 8px;
-	}
-
-	.top-left {
-		top: 0;
-		left: 0;
-		border-right: none;
-		border-bottom: none;
-	}
-
-	.top-right {
-		top: 0;
-		right: 0;
-		border-left: none;
-		border-bottom: none;
-	}
-
-	.bottom-left {
-		bottom: 0;
-		left: 0;
-		border-right: none;
-		border-top: none;
-	}
-
-	.bottom-right {
-		bottom: 0;
-		right: 0;
-		border-left: none;
-		border-top: none;
-	}
-
-	.error-content {
-		width: 100%;
-		background: linear-gradient(135deg, hsl(var(--card)), hsl(38 20% 80%));
+	.error-card {
+		position: relative;
+		z-index: 1;
+		padding: 3rem 2.5rem;
 		border-radius: calc(var(--radius) * 2);
-		padding: 4rem 3rem;
-		box-shadow:
-			0 10px 40px -10px hsl(var(--background) / 0.8),
-			inset 0 1px 0 hsl(42 30% 90% / 0.4);
-		border: 1px solid hsl(var(--secondary) / 0.2);
-		backdrop-filter: blur(10px);
+		box-shadow: var(--shadow-antique);
+		background: var(--gradient-antique);
+		border: 1px solid hsl(var(--border));
+		min-width: 320px;
+		max-width: 600px;
+		width: 100%;
+		margin: 0 2rem;
+		transition: var(--transition-elegant);
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		gap: 2rem;
+		text-align: center;
+	}
+
+	.error-card:hover {
+		box-shadow: var(--gradient-shadow);
+		transform: translateY(-2px);
 	}
 
 	.error-code {
-		font-size: 8rem;
+		font-size: 5rem;
 		font-weight: 700;
-		background: linear-gradient(135deg, hsl(var(--primary)), hsl(1 70% 45%));
-		-webkit-background-clip: text;
-		-webkit-text-fill-color: transparent;
-		background-clip: text;
+		color: #dc2626;
 		line-height: 1;
-		margin: 0;
-		letter-spacing: 0.1em;
-		filter: drop-shadow(0 4px 12px hsl(var(--primary) / 0.3));
+		margin: 0 0 1.5rem 0;
+		letter-spacing: -0.02em;
+		opacity: 0.8;
 	}
 
-	.action-area {
-		margin-top: 1rem;
-		width: 100%;
+	.error-title {
+		font-size: 2rem;
+		font-weight: 600;
+		color: hsl(var(--card-foreground));
+		margin: 0 0 1rem 0;
+		letter-spacing: 0.05em;
+		text-shadow: 0 2px 4px hsl(var(--background) / 0.3);
+	}
+
+	.error-subtitle {
+		font-size: 1rem;
+		color: hsl(var(--muted-foreground));
+		margin: 0 0 2rem 0;
+		line-height: 1.6;
+	}
+
+	.gradient-divider {
+		width: 8rem;
+		height: 0.2rem;
+		background: linear-gradient(to right, hsl(var(--primary)), hsl(var(--secondary)));
+		margin: 1.5rem auto;
+		border-radius: 9999px;
+	}
+
+	.footer-text {
+		position: relative;
+		z-index: 1;
+		margin-top: 2rem;
+		color: hsl(var(--muted-foreground));
+		font-size: 1.1rem;
+		font-style: italic;
+		opacity: 0.8;
 		display: flex;
-		justify-content: center;
+		align-items: center;
+		gap: 1rem;
+		width: 100%;
+		max-width: 600px;
+	}
+
+	.footer-text::before,
+	.footer-text::after {
+		content: '';
+		flex: 1;
+		height: 1px;
+		background: linear-gradient(
+			to right,
+			transparent,
+			hsl(var(--muted-foreground) / 0.3),
+			transparent
+		);
 	}
 
 	@media (max-width: 768px) {
-		.error-page {
-			padding: 1rem;
+		.error-layout {
+			padding: 1rem 0;
 		}
 
-		.error-content {
-			padding: 3rem 2rem;
+		.main-title {
+			font-size: 2.5rem;
 		}
 
-		.error-code {
-			font-size: 5rem;
+		.error-card {
+			margin: 0 1rem;
+			padding: 2rem 1.5rem;
 		}
 
-		.ancient-pattern {
-			width: 50px;
-			height: 50px;
-		}
-
-		.error-decoration {
-			top: -20px;
-			left: -20px;
-			right: -20px;
-			bottom: -20px;
-		}
-	}
-
-	@media (max-width: 480px) {
 		.error-code {
 			font-size: 4rem;
 		}
 
-		.ancient-pattern {
-			width: 40px;
-			height: 40px;
+		.error-title {
+			font-size: 1.5rem;
+		}
+
+		.error-subtitle {
+			font-size: 0.9rem;
 		}
 	}
 </style>

--- a/src/routes/api/user/stats/+server.ts
+++ b/src/routes/api/user/stats/+server.ts
@@ -1,0 +1,139 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { db } from '$lib/server/db';
+import { games, gamePlayers, roles } from '$lib/server/db/schema';
+import { eq, and, isNotNull, desc } from 'drizzle-orm';
+
+export const GET: RequestHandler = async ({ locals }) => {
+	if (!locals.user) {
+		return json({ message: '未授權' }, { status: 401 });
+	}
+
+	try {
+		const userId = locals.user.id;
+
+		// 查詢用戶參與的所有已完成遊戲
+		const userGames = await db
+			.select({
+				gameId: gamePlayers.gameId,
+				roleId: gamePlayers.roleId,
+				roleName: roles.name,
+				roleCamp: roles.camp,
+				gameStatus: games.status,
+				totalScore: games.totalScore,
+				finishedAt: games.finishedAt
+			})
+			.from(gamePlayers)
+			.innerJoin(games, eq(gamePlayers.gameId, games.id))
+			.leftJoin(roles, eq(gamePlayers.roleId, roles.id))
+			.where(
+				and(
+					eq(gamePlayers.userId, userId),
+					eq(games.status, 'finished'),
+					isNotNull(gamePlayers.roleId)
+				)
+			)
+			.orderBy(desc(games.finishedAt));
+
+		// 統計數據
+		let xuYuanWins = 0;
+		let laoChaoFengWins = 0;
+		const roleStats: Record<string, number> = {};
+		const recentGames: Array<{
+			gameId: string;
+			roleName: string;
+			camp: string;
+			result: string;
+			score: number;
+			finishedAt: Date | null;
+		}> = [];
+
+		for (const game of userGames) {
+			// 跳過沒有角色或陣營的數據
+			if (!game.roleName || !game.roleCamp) {
+				continue;
+			}
+
+			// 跳過明顯的測試角色名稱
+			const invalidRoleNames = ['test', 'undefined', 'null', ''];
+			const roleNameLower = game.roleName.toLowerCase().trim();
+			if (invalidRoleNames.includes(roleNameLower)) {
+				continue;
+			}
+
+			const roleName = game.roleName;
+			const roleCamp = game.roleCamp;
+
+			// 將 good/bad 轉換為中文陣營名稱
+			let campDisplayName: string;
+			if (roleCamp === 'good') {
+				campDisplayName = '許愿陣營';
+			} else if (roleCamp === 'bad') {
+				campDisplayName = '老朝奉陣營';
+			} else {
+				// 如果陣營不是 good 或 bad，跳過
+				continue;
+			}
+
+			// 統計角色使用次數
+			roleStats[roleName] = (roleStats[roleName] || 0) + 1;
+
+			// 判斷勝負
+			let result = '未知';
+			const isGoodCamp = roleCamp === 'good'; // good = 許愿陣營
+			const score = game.totalScore || 0;
+
+			if (isGoodCamp) {
+				// 許愿陣營（good）：6 分以上獲勝
+				if (score >= 6) {
+					result = '勝利';
+					xuYuanWins++;
+				} else {
+					result = '失敗';
+				}
+			} else {
+				// 老朝奉陣營（bad）：阻止許愿陣營達到 6 分
+				if (score < 6) {
+					result = '勝利';
+					laoChaoFengWins++;
+				} else {
+					result = '失敗';
+				}
+			}
+
+			// 添加到近期遊戲記錄（使用中文陣營名稱）
+			recentGames.push({
+				gameId: game.gameId,
+				roleName,
+				camp: campDisplayName,
+				result,
+				score,
+				finishedAt: game.finishedAt
+			});
+		}
+
+		// 重新計算總場次（基於有效遊戲）
+		const validTotalGames = recentGames.length;
+
+		// 計算勝率
+		const totalWins = xuYuanWins + laoChaoFengWins;
+		const winRate = validTotalGames > 0 ? Math.round((totalWins / validTotalGames) * 100) : 0;
+
+		// 找出最常使用的角色
+		const sortedRoles = Object.entries(roleStats)
+			.sort((a, b) => b[1] - a[1])
+			.map(([name, count]) => ({ name, count }));
+
+		return json({
+			totalGames: validTotalGames,
+			totalWins,
+			winRate,
+			xuYuanWins,
+			laoChaoFengWins,
+			roleStats: sortedRoles,
+			recentGames: recentGames.slice(0, 5) // 只返回最近 5 場
+		});
+	} catch (error) {
+		console.error('獲取用戶統計失敗:', error);
+		return json({ message: '獲取統計資料失敗' }, { status: 500 });
+	}
+};


### PR DESCRIPTION
- 新增用戶戰績統計 API (GET /api/user/stats)
  - 顯示總場次、勝場、勝率統計
  - 顯示許愿陣營與老朝奉陣營勝場數
  - 顯示角色使用統計與近期戰績
- 新增 UserStatsModal 組件顯示用戶戰績
  - 響應式設計，支援手機與桌面
  - 整合到 UserArea 下拉選單
- 重新設計錯誤頁面 (+error.svelte)
  - 採用登入介面風格（模糊背景、卡片設計）
  - 使用 ActionButton 組件保持一致性
  - 錯誤碼使用深紅色 (#dc2626)
  - 文字顏色參考全站風格
  - 底部文字加入左右漸變襯線
- 統一 FooterDecoration 組件樣式
  - 移除多餘裝飾與動畫
  - 與首頁底部文字樣式一致
- 修復 useLeaveRoom 的 credentials 問題
  - 新增 credentials: 'include' 防止登出問題