### PR TITLE
fix(game): 修正已交棒玩家的攻擊生效回合

### DIFF
--- a/src/lib/server/__tests__/game-turn-order.test.ts
+++ b/src/lib/server/__tests__/game-turn-order.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { getAttackedRound, hasPlayerTakenTurn } from '../game-turn-order';
+
+describe('game turn order', () => {
+	it('treats a player in actionOrder as having taken a turn even without an action record', () => {
+		const actionOrder = [1461, 1459, 1458, 1460, 1464, 1463, 1465];
+
+		expect(hasPlayerTakenTurn(actionOrder, 1465)).toBe(true);
+		expect(getAttackedRound(2, actionOrder, 1465)).toBe(3);
+	});
+
+	it('applies an attack in the current round when the target has not taken a turn', () => {
+		const actionOrder = [1461, 1463, 1460, 1459, 1458];
+
+		expect(hasPlayerTakenTurn(actionOrder, 1462)).toBe(false);
+		expect(getAttackedRound(1, actionOrder, 1462)).toBe(1);
+	});
+
+	it('does not treat the current player as having completed their turn', () => {
+		const actionOrder = [1465, 1463, 1464];
+
+		expect(hasPlayerTakenTurn(actionOrder, 1465)).toBe(false);
+		expect(getAttackedRound(2, actionOrder, 1465)).toBe(2);
+	});
+
+	it('handles an absent or malformed action order conservatively', () => {
+		expect(getAttackedRound(2, null, 1465)).toBe(2);
+		expect(getAttackedRound(2, {}, 1465)).toBe(2);
+	});
+});

--- a/src/lib/server/game-turn-order.ts
+++ b/src/lib/server/game-turn-order.ts
@@ -1,0 +1,20 @@
+/**
+ * actionOrder stores the current/latest player first. Players that already had
+ * their turn remain behind the current player, even when they performed no
+ * action and therefore have no gameActions row.
+ */
+export function hasPlayerTakenTurn(actionOrder: unknown, playerId: number): boolean {
+	if (!Array.isArray(actionOrder)) return false;
+
+	// Index 0 is the player whose turn is currently in progress. Only players
+	// behind them have completed/passed their turn.
+	return actionOrder.slice(1).some((orderedPlayerId) => Number(orderedPlayerId) === playerId);
+}
+
+export function getAttackedRound(
+	currentRound: number,
+	actionOrder: unknown,
+	targetPlayerId: number
+): number {
+	return hasPlayerTakenTurn(actionOrder, targetPlayerId) ? currentRound + 1 : currentRound;
+}

--- a/src/routes/api/room/[name]/attack-player/+server.ts
+++ b/src/routes/api/room/[name]/attack-player/+server.ts
@@ -8,6 +8,7 @@ import {
 } from '$lib/server/api-helpers';
 import { db } from '$lib/server/db';
 import { gamePlayers, gameActions, user, roles } from '$lib/server/db/schema';
+import { getAttackedRound } from '$lib/server/game-turn-order';
 import { eq, and } from 'drizzle-orm';
 
 // 定義受影響的玩家類型
@@ -213,33 +214,20 @@ export const POST: RequestHandler = async ({ request, params }) => {
 		);
 	}
 
-	// 檢查目標玩家是否已經在當前回合行動過
-	const targetPlayerActions = await db
-		.select()
-		.from(gameActions)
-		.where(
-			and(
-				eq(gameActions.gameId, game.id),
-				eq(gameActions.roundId, currentRound.id),
-				eq(gameActions.playerId, targetPlayerId)
-			)
-		);
-
-	const targetHasActed = targetPlayerActions.length > 0;
-
 	// 处理攻击效果
 	const isPermanentBlock = targetRole?.name === '姬云浮';
 
 	// 計算被攻擊的回合數
+	// actionOrder 會保留所有已輪到的玩家，即使玩家沒有使用技能、沒有 gameActions 紀錄。
+	// 因此不能用 gameActions 判斷玩家是否已行動，否則直接交棒的玩家會被錯判為尚未行動。
 	// 姬云浮也根據是否行動過記錄對應的回合，不設定為 999
 	// - 目標已行動：記錄為下一回合 (currentRound + 1)
 	// - 目標未行動：記錄為當前回合 (currentRound)
-	let attackedRoundValue: number;
-	if (targetHasActed) {
-		attackedRoundValue = currentRound.round + 1;
-	} else {
-		attackedRoundValue = currentRound.round;
-	}
+	const attackedRoundValue = getAttackedRound(
+		currentRound.round,
+		currentRound.actionOrder,
+		targetPlayerId
+	);
 
 	// 更新目标玩家的被攻擊狀態
 	await updatePlayerAttackedStatus(targetPlayerId, attackedRoundValue);
@@ -254,20 +242,11 @@ export const POST: RequestHandler = async ({ request, params }) => {
 		const xuYuanPlayer = await getPlayerByRoleName(game.id, '許愿');
 
 		if (xuYuanPlayer) {
-			// 檢查許愿是否已行動
-			const xuYuanActions = await db
-				.select()
-				.from(gameActions)
-				.where(
-					and(
-						eq(gameActions.gameId, game.id),
-						eq(gameActions.roundId, currentRound.id),
-						eq(gameActions.playerId, xuYuanPlayer.playerId)
-					)
-				);
-
-			const xuYuanHasActed = xuYuanActions.length > 0;
-			const xuYuanAttackedRound = xuYuanHasActed ? currentRound.round + 1 : currentRound.round;
+			const xuYuanAttackedRound = getAttackedRound(
+				currentRound.round,
+				currentRound.actionOrder,
+				xuYuanPlayer.playerId
+			);
 
 			// 許愿的被攻擊記錄邏輯與方震相同
 			await updatePlayerAttackedStatus(xuYuanPlayer.playerId, xuYuanAttackedRound);


### PR DESCRIPTION
## 變更內容

- 改用 `actionOrder` 判斷目標玩家是否已經完成／略過本輪行動
- 不再以是否存在 `gameActions` 紀錄判斷玩家是否已行動
- 同步修正攻擊方震時，許愿受到連帶影響的回合判定
- 新增 production 案例的回歸測試

## 根本原因

玩家可以不使用技能直接交棒，此時會出現在回合的 `actionOrder`，但不會產生 `gameActions` 紀錄。舊邏輯因此把已交棒的玩家誤判為尚未行動，將藥不然攻擊效果記在當前回合，而不是下一回合，造成復盤顯示錯誤。

## 影響

攻擊已完成或略過本輪行動的玩家時，效果現在會正確記錄於下一回合；尚未輪到的玩家仍於當前回合受影響。

## 驗證

- `vitest`：4 個回歸測試通過
- `eslint`：通過
- `svelte-check`：0 errors / 0 warnings
- `npm run build`：通過
- 本地 devcontainer 未掛載 Docker daemon，Docker image build 交由 GitHub CI/CD 執行