### PR TITLE
fix: 改善開發容器與部署健康檢查

### DIFF
--- a/.devcontainer/CONFIGURATION.md
+++ b/.devcontainer/CONFIGURATION.md
@@ -108,8 +108,8 @@ Volume 掛載設定：
 
 ### 已安裝工具
 
-- **基礎**: Node.js 22 Alpine
-- **Shell**: Bash, Zsh, oh-my-zsh
+- **基礎**: Node.js 24 Alpine
+- **Shell**: Bash（彩色提示字元與 Git 分支）
 - **版本控制**: Git, SSH client
 - **編輯器**: Vim, Nano
 - **資料庫**: PostgreSQL client
@@ -120,7 +120,7 @@ Volume 掛載設定：
 
 - **預設使用者**: `node` (非 root)
 - **Sudo 權限**: 無需密碼
-- **預設 Shell**: Zsh with oh-my-zsh
+- **預設 Shell**: Bash
 
 ## 自訂設定
 

--- a/.devcontainer/Dockerfile.devcontainer
+++ b/.devcontainer/Dockerfile.devcontainer
@@ -36,11 +36,17 @@ RUN echo "node ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/node \
 	&& chmod 0440 /etc/sudoers.d/node \
 	&& adduser node docker || true
 
+# 使用 Bash 作為登入 Shell，並提供彩色提示字元與常用指令輸出
+RUN usermod -s /bin/bash node
+COPY --chown=node:node .devcontainer/bashrc /home/node/.bashrc
+
 # 建立 Playwright 瀏覽器目錄並建立符號連結到系統 Chromium
 RUN mkdir -p /workspace/.browsers/chromium_headless_shell-1193/chrome-linux && \
 	mkdir -p /workspace/.browsers/chromium-1193/chrome-linux && \
 	ln -s /usr/bin/chromium-browser /workspace/.browsers/chromium_headless_shell-1193/chrome-linux/headless_shell && \
-	ln -s /usr/bin/chromium-browser /workspace/.browsers/chromium-1193/chrome-linux/chrome
+	ln -s /usr/bin/chromium-browser /workspace/.browsers/chromium-1193/chrome-linux/chrome && \
+	mkdir -p /workspace/node_modules && \
+	chown node:node /workspace/node_modules
 
 # 切換到 node 使用者
 USER node
@@ -54,6 +60,7 @@ ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 # 設定環境變數
 ENV NODE_ENV=development
+ENV SHELL=/bin/bash
 ENV PATH="/workspace/node_modules/.bin:${PATH}"
 
 # 預設指令

--- a/.devcontainer/bashrc
+++ b/.devcontainer/bashrc
@@ -1,0 +1,25 @@
+# Skip the interactive prompt setup for scripts and other non-interactive shells.
+case $- in
+	*i*) ;;
+	*) return ;;
+esac
+
+# Keep command output readable in VS Code's integrated terminal.
+export CLICOLOR=1
+alias ls='ls --color=auto'
+alias ll='ls -alF --color=auto'
+alias la='ls -A --color=auto'
+alias l='ls -CF --color=auto'
+alias grep='grep --color=auto'
+alias egrep='grep -E --color=auto'
+alias fgrep='grep -F --color=auto'
+
+# Show the current Git branch without failing outside a repository.
+__git_branch() {
+	local branch
+	branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null)" || return
+	printf ' (%s)' "$branch"
+}
+
+PROMPT_DIRTRIM=3
+PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00;33m\]$(__git_branch)\[\033[00m\]\$ '

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {
+			"version": "1.3.8",
+			"resolved": "ghcr.io/devcontainers/features/git@sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2",
+			"integrity": "sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2"
+		}
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"workspaceFolder": "/workspace",
 
 	// 容器建立後要執行的指令
-	"postCreateCommand": "npm install && npm run db:migrate",
+	"postCreateCommand": "sudo chown -R node:node /workspace/node_modules && npm install && npm run db:migrate",
 
 	// 容器啟動後要執行的指令
 	"postStartCommand": "git config --global --add safe.directory /workspace && git config --global core.autocrlf input",
@@ -42,7 +42,8 @@
 				"wayou.vscode-todo-highlight",
 				"gruntfuggly.todo-tree",
 
-				"github.copilot-chat"
+				"github.copilot-chat",
+				"openai.chatgpt"
 			],
 
 			// 編輯器設定

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -46,7 +46,7 @@ services:
     container_name: moa_devcontainer_postgres
     restart: unless-stopped
     ports:
-      - '${POSTGRES_PORT:-5432}:5432'
+      - '${POSTGRES_PORT:-5433}:5432'
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-moa_user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-moa_pass}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -224,12 +224,22 @@ jobs:
       - name: 🏥 健康檢查
         env:
           DEPLOY_URL: ${{ vars.DEPLOY_URL }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
+          if [ -z "$DEPLOY_URL" ] || [ -z "$CF_ACCESS_CLIENT_ID" ] || [ -z "$CF_ACCESS_CLIENT_SECRET" ]; then
+            echo "❌ 健康檢查所需的 DEPLOY_URL 或 Cloudflare Access Service Token 未設定！"
+            exit 1
+          fi
+
           max_attempts=10
           attempt=1
-          while [ $attempt -le $max_attempts ]; do
+          while [ "$attempt" -le "$max_attempts" ]; do
             echo "嘗試 $attempt/$max_attempts..."
-            if curl -fsS "$DEPLOY_URL/api/health" > /dev/null; then
+            if curl -fsS \
+              -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+              -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+              "$DEPLOY_URL/api/health" > /dev/null; then
               echo "✅ 健康檢查通過！"
               exit 0
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 # OS
 .DS_Store
 Thumbs.db
+/nul
 
 # Env
 .env


### PR DESCRIPTION
## 變更內容

- 將 Dev Container 升級為 Node.js 24，改用 Bash 並加入彩色提示字元與 Git 分支顯示
- 修正 `node_modules` 目錄權限，加入 Dev Container feature lock file，並調整 PostgreSQL 預設連接埠
- 在部署健康檢查中驗證必要設定，並帶入 Cloudflare Access Service Token headers
- 忽略 Windows 環境可能誤產生的根目錄 `nul` 檔案
- 補充對應的 Dev Container 文件與 VS Code extension 設定

## 原因與影響

Dev Container 原本可能因掛載目錄權限造成 `npm install` 失敗，且預設資料庫連接埠容易與本機 PostgreSQL 衝突。部署站點受 Cloudflare Access 保護後，未帶 Service Token 的健康檢查會被擋下，導致部署流程誤判失敗。

這些調整讓開發容器建立流程更穩定，並讓 CD 健康檢查能正確存取受保護的服務。

## 驗證

- `bash -n .devcontainer/bashrc`
- Dev Container lock JSON 解析
- Prettier 格式檢查
- `npm run check`（0 errors / 0 warnings）
- `npm run build`
- Git pre-commit checks

Docker Compose config 與 Docker image build 未執行：目前執行環境沒有 Docker CLI 或 daemon。