### PR TITLE
fix(cd): 改由源站驗證部署健康度

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -221,35 +221,6 @@ jobs:
           echo "❌ 達到最大重試次數，部署失敗！"
           exit 1
 
-      - name: 🏥 健康檢查
-        env:
-          DEPLOY_URL: ${{ vars.DEPLOY_URL }}
-          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-        run: |
-          if [ -z "$DEPLOY_URL" ] || [ -z "$CF_ACCESS_CLIENT_ID" ] || [ -z "$CF_ACCESS_CLIENT_SECRET" ]; then
-            echo "❌ 健康檢查所需的 DEPLOY_URL 或 Cloudflare Access Service Token 未設定！"
-            exit 1
-          fi
-
-          max_attempts=10
-          attempt=1
-          while [ "$attempt" -le "$max_attempts" ]; do
-            echo "嘗試 $attempt/$max_attempts..."
-            if curl -fsS \
-              -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
-              -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-              "$DEPLOY_URL/api/health" > /dev/null; then
-              echo "✅ 健康檢查通過！"
-              exit 0
-            fi
-            echo "⏳ 等待服務啟動..."
-            sleep 10
-            attempt=$((attempt + 1))
-          done
-          echo "❌ 健康檢查失敗！"
-          exit 1
-
       - name: 🧹 清理 SSH 金鑰
         if: always()
         run: shred -u ~/.ssh/deploy_key

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -126,23 +126,26 @@ sleep 10
 
 echo "🏥 檢查服務健康狀態..."
 max_attempts=10
-attempt=0
+attempt=1
+health_response=""
 
-while [ $attempt -lt $max_attempts ]; do
-    if curl -s http://localhost:5173/api/health > /dev/null 2>&1; then
+while [ "$attempt" -le "$max_attempts" ]; do
+    if health_response=$(curl -fsS http://localhost:5173/api/health 2>/dev/null) && \
+        printf '%s' "$health_response" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"ok"'; then
         echo "✅ 服務健康檢查通過！"
         break
     fi
 
-    attempt=$((attempt + 1))
-    if [ $attempt -eq $max_attempts ]; then
-        echo "⚠️  警告：服務健康檢查超時"
-        echo "請手動檢查服務狀態："
-        echo "  $DOCKER_COMPOSE -f docker-compose.prod.yml logs -f app"
-    else
-        echo "   等待中... ($attempt/$max_attempts)"
-        sleep 2
+    if [ "$attempt" -eq "$max_attempts" ]; then
+        echo "❌ 服務健康檢查失敗"
+        echo "📋 最近的應用日誌："
+        $DOCKER_COMPOSE -f docker-compose.prod.yml logs --tail=100 app || true
+        exit 1
     fi
+
+    echo "   等待中... ($attempt/$max_attempts)"
+    sleep 2
+    attempt=$((attempt + 1))
 done
 
 echo ""


### PR DESCRIPTION
## 問題原因

CD 在 GitHub-hosted runner 上透過公開網址執行健康檢查。Cloudflare 邊緣策略對該 runner 持續回傳 `403`，即使 Service Token 已正確設定，而且相同 Token 的 Cloudflare SSH 與實際部署均成功。

加入 Service Token headers 前後的 CD run 都出現相同 `403`，證明問題不在 header 格式或應用啟動。公開 endpoint 從一般網路目前可正常回傳 `200`。

此外，原本伺服器上的 `deploy-prod.sh` 雖然會檢查本機 endpoint，但健康檢查超時只顯示警告，仍會讓部署成功。

## 修正內容

- 移除受 Cloudflare/WAF 影響的 GitHub runner 外部健康檢查
- 將部署結果改由伺服器本機 `http://localhost:5173/api/health` 判定
- 同時驗證 HTTP 成功與 JSON 的 `status: ok`
- 健康檢查失敗時輸出最近 100 行 app logs 並以非零狀態結束部署

## 影響

CD 不再因 GitHub runner 的 Cloudflare `403` 誤判部署失败，同时真正的应用启动或健康异常仍会阻止部署成功。

## 驗證

- `bash -n deploy-prod.sh`
- Prettier workflow 格式檢查
- `npm run check`（0 errors / 0 warnings）
- `npm run build`
- Git pre-commit checks

Docker image build 未執行：目前環境沒有 Docker CLI 或 daemon。