### PR TITLE
fix(game): 統一公開投票結果 (#104)

### DIFF
--- a/e2e/game-flow.test.ts
+++ b/e2e/game-flow.test.ts
@@ -1441,6 +1441,22 @@ test.describe('Game Flow', () => {
 
 								console.log(`   ${rankBadge} ${beastName}: ${voteCount} - ${status?.trim() || ''}`);
 							}
+
+							const hostResult = await topTwoResults.evaluateAll((cards) =>
+								cards.map((card) => (card as HTMLElement).innerText.replace(/\s+/g, ' ').trim())
+							);
+
+							// 公開結果是伺服器權威資料；所有非房主必須與房主完全一致。
+							for (let playerIndex = 1; playerIndex < pages.length; playerIndex++) {
+								const playerPanel = pages[playerIndex].locator('.voting-result-panel');
+								await expect(playerPanel).toBeVisible({ timeout: 10000 });
+								const playerResult = await playerPanel
+									.locator('.result-card')
+									.evaluateAll((cards) =>
+										cards.map((card) => (card as HTMLElement).innerText.replace(/\s+/g, ' ').trim())
+									);
+								expect(playerResult).toEqual(hostResult);
+							}
 						}
 
 						// 如果是房主且不是第3回合，點擊開始下一回合

--- a/src/lib/components/ui/ArtifactDisplay.svelte
+++ b/src/lib/components/ui/ArtifactDisplay.svelte
@@ -4,7 +4,7 @@
 	interface BeastHead {
 		id: number;
 		animal: string;
-		isGenuine: boolean;
+		identifiedIsGenuine?: boolean;
 		votes: number;
 		voteRank?: number | null; // 投票排名
 	}
@@ -138,10 +138,6 @@
 		if (identifiedArtifacts.includes(beast.id)) {
 			return true;
 		}
-		// 如果是投票結果階段，只顯示排名第二的獸首真偽
-		if (showVotingResults && beast.voteRank === 2) {
-			return true;
-		}
 		return false;
 	}
 </script>
@@ -183,8 +179,8 @@
 						</div>
 						<div class="beast-name">{beast.animal}</div>
 						{#if shouldShowGenuine(beast)}
-							<div class="beast-status" class:is-real={beast.isGenuine}>
-								{beast.isGenuine ? '真品' : '贗品'}
+							<div class="beast-status" class:is-real={beast.identifiedIsGenuine}>
+								{beast.identifiedIsGenuine ? '真品' : '贗品'}
 							</div>
 						{:else if failedIdentifications.includes(beast.id)}
 							<div class="beast-status failed">無法鑑定</div>

--- a/src/lib/components/ui/VotingPanel.svelte
+++ b/src/lib/components/ui/VotingPanel.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import Portal from '$lib/components/ui/Portal.svelte';
 	import { addNotification } from '$lib/stores/notifications';
+	import type { PublishedVotingResult } from '$lib/types/game';
 
 	interface BeastHead {
 		id: number;
 		animal: string;
-		isGenuine: boolean;
 		votes: number;
 	}
 
@@ -13,7 +13,7 @@
 	export let beastHeads: BeastHead[] = [];
 	export let identifiedArtifacts: number[] = [];
 	export let isHost: boolean = false;
-	export let onVotesSubmitted: () => void = () => {};
+	export let onVotesSubmitted: (result: PublishedVotingResult) => void = () => {};
 
 	// Suppress unused warning - kept for future use
 	$: void identifiedArtifacts;
@@ -108,8 +108,9 @@
 			});
 
 			if (response.ok) {
+				const data = await response.json();
 				addNotification('投票提交成功', 'success');
-				onVotesSubmitted();
+				onVotesSubmitted(data.votingResult);
 			} else {
 				const error = await response.json();
 				addNotification(error.message || '提交投票失敗', 'error');

--- a/src/lib/components/ui/VotingResultPanel.svelte
+++ b/src/lib/components/ui/VotingResultPanel.svelte
@@ -2,25 +2,15 @@
 	import SettlementButton from '$lib/components/game/SettlementButton.svelte';
 	import Portal from '$lib/components/ui/Portal.svelte';
 	import { addNotification } from '$lib/stores/notifications';
+	import type { PublishedVotingResult } from '$lib/types/game';
 	import { chineseNumeral } from '$lib/utils/round';
 
-	interface BeastHead {
-		id: number;
-		animal: string;
-		isGenuine: boolean;
-		votes: number;
-		voteRank?: number | null;
-	}
-
 	export let roomName: string;
-	export let beastHeads: BeastHead[] = [];
+	export let votingResult: PublishedVotingResult | null = null;
 	export let isHost: boolean = false;
 	export let currentRound: number = 1;
 	export let onNextRound: () => void = () => {};
 	export let isOpen: boolean = true;
-
-	// 十二生肖順序
-	const ZODIAC_ORDER = ['鼠', '牛', '虎', '兔', '龍', '蛇', '馬', '羊', '猴', '雞', '狗', '豬'];
 
 	let isStartingNextRound = false;
 
@@ -31,20 +21,7 @@
 		return rank.toString();
 	};
 
-	// 排序獸首並獲取前兩名
-	$: sortedBeasts = beastHeads
-		.filter((b) => b.votes >= 0)
-		.sort((a, b) => {
-			if (b.votes !== a.votes) {
-				return b.votes - a.votes;
-			}
-			// 票數相同時按生肖順序
-			const orderA = ZODIAC_ORDER.indexOf(a.animal);
-			const orderB = ZODIAC_ORDER.indexOf(b.animal);
-			return orderA - orderB;
-		});
-
-	$: topTwo = sortedBeasts.slice(0, 2);
+	$: topTwo = votingResult ? [votingResult.firstPlace, votingResult.secondPlace] : [];
 
 	const startNextRound = async () => {
 		if (isStartingNextRound) return;
@@ -86,7 +63,7 @@
 					<p class="result-description">本回合投票已完成</p>
 				</div>
 				<div class="result-content">
-					{#if topTwo && topTwo.length > 0}
+					{#if votingResult && topTwo.length === 2}
 						<div class="all-results">
 							{#each topTwo as beast, index (beast.id)}
 								<div class="result-card" class:top-one={index === 0} class:top-two={index === 1}>
@@ -99,8 +76,11 @@
 										<div class="beast-status-pending">待揭曉</div>
 									{:else if index === 1}
 										<!-- 第二名一定會公布真偽 -->
-										<div class="beast-status-large" class:is-real={beast.isGenuine}>
-											{beast.isGenuine ? '真品 ✓' : '贗品 ✗'}
+										<div
+											class="beast-status-large"
+											class:is-real={votingResult.secondPlace.isGenuine}
+										>
+											{votingResult.secondPlace.isGenuine ? '真品 ✓' : '贗品 ✗'}
 										</div>
 									{/if}
 								</div>
@@ -108,7 +88,7 @@
 						</div>
 					{:else}
 						<div class="no-votes-message">
-							<p>尚未有投票結果</p>
+							<p>載入投票結果中...</p>
 						</div>
 					{/if}
 

--- a/src/lib/server/__tests__/game-voting.test.ts
+++ b/src/lib/server/__tests__/game-voting.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { buildPublishedVotingResult } from '../game-voting';
+
+describe('buildPublishedVotingResult', () => {
+	it('只使用持久化排名建立一致的公開結果', () => {
+		const result = buildPublishedVotingResult(2, [
+			{ id: 12, animal: '虎', votes: 3, voteRank: 2, isGenuine: false },
+			{ id: 11, animal: '牛', votes: 5, voteRank: 1, isGenuine: true }
+		]);
+
+		expect(result).toEqual({
+			round: 2,
+			firstPlace: { id: 11, animal: '牛', votes: 5, rank: 1 },
+			secondPlace: { id: 12, animal: '虎', votes: 3, rank: 2, isGenuine: false }
+		});
+	});
+
+	it('缺少任一名次時拒絕建立假結果', () => {
+		const result = buildPublishedVotingResult(1, [
+			{ id: 11, animal: '牛', votes: 5, voteRank: 1, isGenuine: true }
+		]);
+
+		expect(result).toBeNull();
+	});
+});

--- a/src/lib/server/game-voting.ts
+++ b/src/lib/server/game-voting.ts
@@ -1,0 +1,74 @@
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import type { PublishedVotingResult } from '$lib/types/game';
+import { db } from './db';
+import { gameArtifacts } from './db/schema';
+
+type DatabaseExecutor = Pick<typeof db, 'select'>;
+
+interface RankedVotingArtifact {
+	id: number;
+	animal: string;
+	votes: number | null;
+	voteRank: number | null;
+	isGenuine: boolean;
+}
+
+export function buildPublishedVotingResult(
+	round: number,
+	rankedArtifacts: RankedVotingArtifact[]
+): PublishedVotingResult | null {
+	const firstPlace = rankedArtifacts.find((artifact) => artifact.voteRank === 1);
+	const secondPlace = rankedArtifacts.find((artifact) => artifact.voteRank === 2);
+
+	if (!firstPlace || !secondPlace) {
+		return null;
+	}
+
+	return {
+		round,
+		firstPlace: {
+			id: firstPlace.id,
+			animal: firstPlace.animal,
+			votes: firstPlace.votes ?? 0,
+			rank: 1
+		},
+		secondPlace: {
+			id: secondPlace.id,
+			animal: secondPlace.animal,
+			votes: secondPlace.votes ?? 0,
+			rank: 2,
+			isGenuine: secondPlace.isGenuine
+		}
+	};
+}
+
+/**
+ * Read the persisted public voting result. Private identification results are
+ * deliberately excluded: the published second-place truth always comes from
+ * gameArtifacts.isGenuine.
+ */
+export async function getPublishedVotingResult(
+	executor: DatabaseExecutor,
+	gameId: string,
+	round: number
+): Promise<PublishedVotingResult | null> {
+	const rankedArtifacts = await executor
+		.select({
+			id: gameArtifacts.id,
+			animal: gameArtifacts.animal,
+			votes: gameArtifacts.votes,
+			voteRank: gameArtifacts.voteRank,
+			isGenuine: gameArtifacts.isGenuine
+		})
+		.from(gameArtifacts)
+		.where(
+			and(
+				eq(gameArtifacts.gameId, gameId),
+				eq(gameArtifacts.round, round),
+				inArray(gameArtifacts.voteRank, [1, 2])
+			)
+		)
+		.orderBy(asc(gameArtifacts.voteRank));
+
+	return buildPublishedVotingResult(round, rankedArtifacts);
+}

--- a/src/lib/services/gameService.ts
+++ b/src/lib/services/gameService.ts
@@ -1,7 +1,21 @@
 // Game API service for all game-related API calls
 import { goto } from '$app/navigation';
 import { addNotification } from '$lib/stores/notifications';
-import type { BeastHead, PerformedAction, SkillActions } from '$lib/types/game';
+import type {
+	BeastHead,
+	PerformedAction,
+	PublishedVotingResult,
+	SkillActions
+} from '$lib/types/game';
+
+export interface RoundStatusResponse {
+	success: boolean;
+	phase: string;
+	round: number;
+	isHost: boolean;
+	gameStatus: string;
+	votingResult: PublishedVotingResult | null;
+}
 
 export class GameService {
 	private roomName: string;
@@ -95,7 +109,7 @@ export class GameService {
 		return null;
 	}
 
-	async fetchRoundStatus() {
+	async fetchRoundStatus(): Promise<RoundStatusResponse | null> {
 		const response = await fetch(`/api/room/${encodeURIComponent(this.roomName)}/round-status`, {
 			credentials: 'include',
 			headers: this.getReadHeaders()

--- a/src/lib/stores/__tests__/gameState.test.ts
+++ b/src/lib/stores/__tests__/gameState.test.ts
@@ -1,0 +1,41 @@
+import { get } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+import { createGameState } from '../gameState';
+
+describe('gameState voting result separation', () => {
+	it('私人鑑定值不會覆蓋公開投票結果', () => {
+		const state = createGameState();
+		state.beastHeads.set([
+			{
+				id: 7,
+				animal: '牛',
+				identifiedIsGenuine: true,
+				votes: 3,
+				voteRank: 2
+			}
+		]);
+		state.publishedVotingResult.set({
+			round: 1,
+			firstPlace: { id: 6, animal: '鼠', votes: 5, rank: 1 },
+			secondPlace: { id: 7, animal: '牛', votes: 3, rank: 2, isGenuine: false }
+		});
+
+		expect(get(state.beastHeads)[0].identifiedIsGenuine).toBe(true);
+		expect(get(state.publishedVotingResult)?.secondPlace.isGenuine).toBe(false);
+	});
+
+	it('開始新回合時清除私人與公開結果', () => {
+		const state = createGameState();
+		state.identifiedArtifacts.set([7]);
+		state.publishedVotingResult.set({
+			round: 1,
+			firstPlace: { id: 6, animal: '鼠', votes: 5, rank: 1 },
+			secondPlace: { id: 7, animal: '牛', votes: 3, rank: 2, isGenuine: false }
+		});
+
+		state.resetForNewRound();
+
+		expect(get(state.identifiedArtifacts)).toEqual([]);
+		expect(get(state.publishedVotingResult)).toBeNull();
+	});
+});

--- a/src/lib/stores/gameState.ts
+++ b/src/lib/stores/gameState.ts
@@ -8,7 +8,9 @@ import type {
 	IdentifiedPlayerResult,
 	GamePhase,
 	PerformedAction,
-	UsedSkills
+	UsedSkills,
+	PublishedVotingResult,
+	FinalArtifact
 } from '$lib/types/game';
 
 export function createGameState() {
@@ -20,6 +22,7 @@ export function createGameState() {
 	const currentRound = writable<number>(1);
 	const roundPhase = writable<string>('action');
 	const isHost = writable<boolean>(false);
+	const publishedVotingResult = writable<PublishedVotingResult | null>(null);
 
 	// Player-specific state
 	const currentPlayerRole = writable<string | null>(null);
@@ -56,7 +59,7 @@ export function createGameState() {
 	const finalResult = writable<{
 		winner: string;
 		xuYuanScore: number;
-		allArtifacts: BeastHead[];
+		allArtifacts: FinalArtifact[];
 		players: Player[];
 		identificationResults?: {
 			laoChaoFeng?: {
@@ -118,6 +121,7 @@ export function createGameState() {
 		currentRound,
 		roundPhase,
 		isHost,
+		publishedVotingResult,
 		currentPlayerRole,
 		skillActions,
 		hasLoadedSkills,
@@ -175,6 +179,7 @@ export function createGameState() {
 			blockedArtifacts.set([]);
 			failedIdentifications.set([]);
 			performedActions.set([]);
+			publishedVotingResult.set(null);
 		}
 	};
 }

--- a/src/lib/types/game.ts
+++ b/src/lib/types/game.ts
@@ -25,11 +25,32 @@ export interface User {
 export interface BeastHead {
 	id: number;
 	animal: string;
-	isGenuine: boolean;
+	identifiedIsGenuine?: boolean;
 	isBlocked?: boolean;
 	votes: number;
 	voteRank?: number | null;
 	round?: number;
+}
+
+export interface PublishedVotingResult {
+	round: number;
+	firstPlace: {
+		id: number;
+		animal: string;
+		votes: number;
+		rank: 1;
+	};
+	secondPlace: {
+		id: number;
+		animal: string;
+		votes: number;
+		rank: 2;
+		isGenuine: boolean;
+	};
+}
+
+export interface FinalArtifact extends BeastHead {
+	isGenuine: boolean;
 }
 
 export interface ActionedPlayer {
@@ -94,7 +115,7 @@ export interface FinalGameResult {
 		xuYuan?: IdentificationResult;
 		fangZhen?: IdentificationResult;
 	};
-	allArtifacts: BeastHead[];
+	allArtifacts: FinalArtifact[];
 	players: Array<{
 		id: number;
 		nickname: string;

--- a/src/routes/api/__tests__/game-phase-voting.test.ts
+++ b/src/routes/api/__tests__/game-phase-voting.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { db } from '$lib/server/db';
-import { user, games, gamePlayers } from '$lib/server/db/schema';
+import { user, games, gamePlayers, gameArtifacts, gameRounds } from '$lib/server/db/schema';
 import { eq } from 'drizzle-orm';
-import { API_BASE, createTestUser, createTestRoom } from './helpers';
+import { API_BASE, createTestUser, createTestRoom, joinTestRoom } from './helpers';
 
 describe('Game Phase APIs - Discussion and Voting', () => {
 	const testUsers: { email: string; token: string; userId: number }[] = [];
@@ -24,6 +24,8 @@ describe('Game Phase APIs - Discussion and Voting', () => {
 		// 清理測試數據
 		for (const gameId of testGames) {
 			try {
+				await db.delete(gameArtifacts).where(eq(gameArtifacts.gameId, gameId));
+				await db.delete(gameRounds).where(eq(gameRounds.gameId, gameId));
 				await db.delete(gamePlayers).where(eq(gamePlayers.gameId, gameId));
 				await db.delete(games).where(eq(games.id, gameId));
 			} catch (error) {
@@ -39,6 +41,31 @@ describe('Game Phase APIs - Discussion and Voting', () => {
 			}
 		}
 	});
+
+	async function createVotingGame() {
+		const room = await createTestRoom(testUsers[0].token);
+		testGames.push(room.gameId);
+		await joinTestRoom(testUsers[1].token, room.roomName, room.password);
+
+		await db.update(games).set({ status: 'playing' }).where(eq(games.id, room.gameId));
+		await db.insert(gameRounds).values({
+			gameId: room.gameId,
+			round: 1,
+			phase: 'voting'
+		});
+
+		const artifacts = await db
+			.insert(gameArtifacts)
+			.values([
+				{ gameId: room.gameId, round: 1, animal: '鼠', isGenuine: true },
+				{ gameId: room.gameId, round: 1, animal: '牛', isGenuine: false },
+				{ gameId: room.gameId, round: 1, animal: '虎', isGenuine: true },
+				{ gameId: room.gameId, round: 1, animal: '兔', isGenuine: false }
+			])
+			.returning();
+
+		return { ...room, artifacts };
+	}
 
 	describe('POST /api/room/[name]/start-discussion', () => {
 		it('應該拒絕未認證的請求', async () => {
@@ -188,6 +215,106 @@ describe('Game Phase APIs - Discussion and Voting', () => {
 			);
 
 			expect([400, 403]).toContain(response.status);
+		});
+	});
+
+	describe('公開投票結果一致性', () => {
+		it('只允許房主提交，並讓所有玩家從 round-status 取得同一結果', async () => {
+			const room = await createVotingGame();
+			const endpoint = `${API_BASE}/api/room/${encodeURIComponent(room.roomName)}`;
+
+			const beforeResult = await fetch(`${endpoint}/round-status`, {
+				headers: { Authorization: `Bearer ${testUsers[1].token}` }
+			});
+			expect(beforeResult.status).toBe(200);
+			expect((await beforeResult.json()).votingResult).toBeNull();
+
+			const privateArtifacts = await fetch(`${endpoint}/artifacts`, {
+				headers: { Authorization: `Bearer ${testUsers[1].token}` }
+			}).then((response) => response.json());
+			expect(privateArtifacts.artifacts).not.toEqual([]);
+			expect(
+				privateArtifacts.artifacts.every((artifact: object) => !('isGenuine' in artifact))
+			).toBe(true);
+
+			const votes = Object.fromEntries(
+				room.artifacts.map((artifact) => [
+					artifact.id,
+					artifact.animal === '鼠' ? 5 : ['牛', '虎'].includes(artifact.animal) ? 3 : 0
+				])
+			);
+
+			const nonHostResponse = await fetch(`${endpoint}/submit-votes`, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${testUsers[1].token}`,
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ votes })
+			});
+			expect(nonHostResponse.status).toBe(403);
+
+			const submitResponse = await fetch(`${endpoint}/submit-votes`, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${testUsers[0].token}`,
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({ votes })
+			});
+			expect(submitResponse.status).toBe(200);
+			const submitted = await submitResponse.json();
+
+			expect(submitted.votingResult.firstPlace).toMatchObject({
+				animal: '鼠',
+				votes: 5,
+				rank: 1
+			});
+			expect(submitted.votingResult.secondPlace).toMatchObject({
+				animal: '牛',
+				votes: 3,
+				rank: 2,
+				isGenuine: false
+			});
+
+			const [hostStatus, playerStatus] = await Promise.all([
+				fetch(`${endpoint}/round-status`, {
+					headers: { Authorization: `Bearer ${testUsers[0].token}` }
+				}).then((response) => response.json()),
+				fetch(`${endpoint}/round-status`, {
+					headers: { Authorization: `Bearer ${testUsers[1].token}` }
+				}).then((response) => response.json())
+			]);
+
+			expect(hostStatus.votingResult).toEqual(submitted.votingResult);
+			expect(playerStatus.votingResult).toEqual(submitted.votingResult);
+		});
+
+		it('並行提交只保存第一個完成的權威結果', async () => {
+			const room = await createVotingGame();
+			const endpoint = `${API_BASE}/api/room/${encodeURIComponent(room.roomName)}`;
+			const votes = Object.fromEntries(
+				room.artifacts.map((artifact, index) => [artifact.id, index + 1])
+			);
+			const request = () =>
+				fetch(`${endpoint}/submit-votes`, {
+					method: 'POST',
+					headers: {
+						Authorization: `Bearer ${testUsers[0].token}`,
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify({ votes })
+				});
+
+			const responses = await Promise.all([request(), request()]);
+			expect(responses.map((response) => response.status).sort()).toEqual([200, 409]);
+
+			const successfulResult = await responses.find((response) => response.status === 200)!.json();
+			const persistedStatus = await fetch(`${endpoint}/round-status`, {
+				headers: { Authorization: `Bearer ${testUsers[0].token}` }
+			}).then((response) => response.json());
+
+			expect(persistedStatus.votingResult).toEqual(successfulResult.votingResult);
 		});
 	});
 

--- a/src/routes/api/room/[name]/artifacts/+server.ts
+++ b/src/routes/api/room/[name]/artifacts/+server.ts
@@ -28,8 +28,6 @@ export const GET: RequestHandler = async ({ request, params }) => {
 		.select({
 			id: gameArtifacts.id,
 			animal: gameArtifacts.animal,
-			isGenuine: gameArtifacts.isGenuine,
-			isSwapped: gameArtifacts.isSwapped,
 			isBlocked: gameArtifacts.isBlocked,
 			votes: gameArtifacts.votes,
 			voteRank: gameArtifacts.voteRank
@@ -48,7 +46,6 @@ export const GET: RequestHandler = async ({ request, params }) => {
 		artifacts: sortedArtifacts.map((artifact) => ({
 			id: artifact.id,
 			animal: artifact.animal,
-			isGenuine: artifact.isGenuine,
 			isBlocked: artifact.isBlocked || false,
 			votes: artifact.votes || 0,
 			voteRank: artifact.voteRank,

--- a/src/routes/api/room/[name]/round-status/+server.ts
+++ b/src/routes/api/room/[name]/round-status/+server.ts
@@ -1,6 +1,8 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { verifyPlayerInRoom, getCurrentRoundOrError } from '$lib/server/api-helpers';
+import { getPublishedVotingResult } from '$lib/server/game-voting';
+import { db } from '$lib/server/db';
 
 // 獲取當前回合狀態
 export const GET: RequestHandler = async ({ request, params }) => {
@@ -19,7 +21,8 @@ export const GET: RequestHandler = async ({ request, params }) => {
 				phase: game.status === 'finished' ? 'finished' : 'terminated',
 				round: 3,
 				isHost: player.isHost,
-				gameStatus: game.status
+				gameStatus: game.status,
+				votingResult: null
 			});
 		}
 
@@ -39,13 +42,22 @@ export const GET: RequestHandler = async ({ request, params }) => {
 			return roundResult.error;
 		}
 		const currentRound = roundResult.round;
+		const votingResult =
+			currentRound.phase === 'result'
+				? await getPublishedVotingResult(db, game.id, currentRound.round)
+				: null;
+
+		if (currentRound.phase === 'result' && !votingResult) {
+			return json({ message: '投票結果資料不完整' }, { status: 500 });
+		}
 
 		return json({
 			success: true,
 			phase: currentRound.phase,
 			round: currentRound.round,
 			isHost: player.isHost,
-			gameStatus: game.status
+			gameStatus: game.status,
+			votingResult
 		});
 	} catch (error) {
 		return json(

--- a/src/routes/api/room/[name]/submit-votes/+server.ts
+++ b/src/routes/api/room/[name]/submit-votes/+server.ts
@@ -1,141 +1,120 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { verifyPlayerInRoomWithStatus } from '$lib/server/api-helpers';
+import { verifyHostWithStatus } from '$lib/server/api-helpers';
 import { db } from '$lib/server/db';
 import { gameArtifacts, gameRounds } from '$lib/server/db/schema';
-import { eq, and } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { ZODIAC_ORDER } from '$lib/server/constants';
 import { emitToRoom } from '$lib/server/socket';
+import { getPublishedVotingResult } from '$lib/server/game-voting';
+
+class VotingSubmissionError extends Error {
+	constructor(
+		message: string,
+		readonly status: number = 400
+	) {
+		super(message);
+	}
+}
 
 export const POST: RequestHandler = async ({ request, params }) => {
 	try {
-		const verifyResult = await verifyPlayerInRoomWithStatus(request, params.name!, 'playing');
+		const verifyResult = await verifyHostWithStatus(request, params.name!, 'playing');
 		if ('error' in verifyResult) {
 			return verifyResult.error;
 		}
 
 		const { game } = verifyResult;
-
-		// 解析請求body
 		const body = await request.json();
-		const { votes } = body;
+		const votes = body.votes as Record<string, unknown> | undefined;
 
-		if (!votes || typeof votes !== 'object') {
+		if (!votes || typeof votes !== 'object' || Array.isArray(votes)) {
 			return json({ message: '投票資料格式錯誤' }, { status: 400 });
 		}
 
-		// 先獲取當前回合資訊
-		const currentRound = await db
-			.select()
-			.from(gameRounds)
-			.where(and(eq(gameRounds.gameId, game.id), eq(gameRounds.phase, 'voting')))
-			.limit(1);
+		const votingResult = await db.transaction(async (tx) => {
+			// Serialize submissions for this game. A second request observes the
+			// committed result phase and cannot overwrite the first result.
+			const [currentRound] = await tx
+				.select()
+				.from(gameRounds)
+				.where(eq(gameRounds.gameId, game.id))
+				.orderBy(desc(gameRounds.round))
+				.limit(1)
+				.for('update');
 
-		if (currentRound.length === 0) {
-			return json({ message: '找不到當前投票回合' }, { status: 400 });
-		}
-
-		const round = currentRound[0].round;
-
-		// 獲取當前回合的所有獸首（加上 round 條件）
-		const artifacts = await db
-			.select()
-			.from(gameArtifacts)
-			.where(and(eq(gameArtifacts.gameId, game.id), eq(gameArtifacts.round, round)));
-
-		// 創建投票數組用於排序
-		const votedArtifacts = artifacts.map((artifact) => ({
-			id: artifact.id,
-			animal: artifact.animal,
-			round: artifact.round,
-			votes: votes[artifact.id.toString()] || 0,
-			isGenuine: artifact.isGenuine
-		}));
-
-		// 排序規則：
-		// 1. 票數高的在前
-		// 2. 同票數時，按12生肖排序（鼠最小，豬最大）
-		votedArtifacts.sort((a, b) => {
-			if (b.votes !== a.votes) {
-				return b.votes - a.votes; // 票數降序
+			if (!currentRound || currentRound.phase !== 'voting') {
+				throw new VotingSubmissionError('找不到當前投票回合', 409);
 			}
-			// 同票數時，按生肖順序
-			const orderA = ZODIAC_ORDER.indexOf(a.animal);
-			const orderB = ZODIAC_ORDER.indexOf(b.animal);
-			return orderA - orderB; // 生肖順序升序（鼠最小）
+
+			const artifacts = await tx
+				.select()
+				.from(gameArtifacts)
+				.where(and(eq(gameArtifacts.gameId, game.id), eq(gameArtifacts.round, currentRound.round)));
+
+			if (artifacts.length < 2) {
+				throw new VotingSubmissionError('當前回合獸首資料不完整');
+			}
+
+			const votedArtifacts = artifacts.map((artifact) => {
+				const rawVote = votes[artifact.id.toString()] ?? 0;
+				if (typeof rawVote !== 'number' || !Number.isInteger(rawVote) || rawVote < 0) {
+					throw new VotingSubmissionError('票數必須是非負整數');
+				}
+
+				return {
+					id: artifact.id,
+					animal: artifact.animal,
+					votes: rawVote
+				};
+			});
+
+			if (!votedArtifacts.some((artifact) => artifact.votes > 0)) {
+				throw new VotingSubmissionError('請至少為一個獸首分配投票數');
+			}
+
+			votedArtifacts.sort((a, b) => {
+				if (b.votes !== a.votes) return b.votes - a.votes;
+				return ZODIAC_ORDER.indexOf(a.animal) - ZODIAC_ORDER.indexOf(b.animal);
+			});
+
+			for (let index = 0; index < votedArtifacts.length; index++) {
+				const artifact = votedArtifacts[index];
+				await tx
+					.update(gameArtifacts)
+					.set({
+						votes: artifact.votes,
+						voteRank: index < 2 ? index + 1 : null
+					})
+					.where(eq(gameArtifacts.id, artifact.id));
+			}
+
+			await tx
+				.update(gameRounds)
+				.set({ phase: 'result' })
+				.where(eq(gameRounds.id, currentRound.id));
+
+			const result = await getPublishedVotingResult(tx, game.id, currentRound.round);
+			if (!result) {
+				throw new VotingSubmissionError('投票結果資料不完整', 500);
+			}
+
+			return result;
 		});
 
-		// 更新獸首的投票數和排名（只更新當前回合的獸首）
-		// 一定會有第一名和第二名（即使第二名是0票）
-		for (let i = 0; i < votedArtifacts.length; i++) {
-			const artifact = votedArtifacts[i];
-			const voteCount = artifact.votes;
-			const rank = i < 2 ? i + 1 : null; // 前兩名一定給排名
-
-			await db
-				.update(gameArtifacts)
-				.set({
-					votes: voteCount,
-					voteRank: rank
-				})
-				.where(eq(gameArtifacts.id, artifact.id));
-		}
-
-		// 更新回合階段為 'result'
-		await db
-			.update(gameRounds)
-			.set({ phase: 'result' })
-			.where(eq(gameRounds.id, currentRound[0].id));
-
-		// 取得第二名的資訊 - 一定會有第二名（即使是0票）
-		const secondPlace = votedArtifacts.length >= 2 ? votedArtifacts[1] : null;
-
-		// 取前兩名（一定會公布前兩名）
-		const topTwo = votedArtifacts.slice(0, 2);
-
-		// 廣播投票結果給房間內所有玩家
-		const eventData = {
-			phase: 'result',
-			topTwo: topTwo.map((a) => ({
-				id: a.id,
-				animal: a.animal,
-				votes: a.votes
-			})),
-			secondPlace: secondPlace
-				? {
-						id: secondPlace.id,
-						animal: secondPlace.animal,
-						votes: secondPlace.votes,
-						isGenuine: secondPlace.isGenuine
-					}
-				: null
-		};
-
-		console.log(`[submit-votes] 準備廣播 voting-completed 事件到房間 ${params.name}`);
-		console.log(`[submit-votes] 事件數據:`, JSON.stringify(eventData, null, 2));
-
-		emitToRoom(params.name!, 'voting-completed', eventData);
-
-		console.log(`[submit-votes] 已調用 emitToRoom`);
+		const eventData = { phase: 'result', votingResult } as const;
+		await emitToRoom(params.name!, 'voting-completed', eventData);
 
 		return json({
 			success: true,
 			message: '投票提交成功',
-			topTwo: topTwo.map((a) => ({
-				id: a.id,
-				animal: a.animal,
-				votes: a.votes
-			})),
-			secondPlace: secondPlace
-				? {
-						id: secondPlace.id,
-						animal: secondPlace.animal,
-						votes: secondPlace.votes,
-						isGenuine: secondPlace.isGenuine
-					}
-				: null
+			votingResult
 		});
 	} catch (error) {
+		if (error instanceof VotingSubmissionError) {
+			return json({ message: error.message }, { status: error.status });
+		}
+
 		console.error('[submit-votes] 錯誤:', error);
 		return json({ message: '投票提交失敗' }, { status: 500 });
 	}

--- a/src/routes/room/[name]/game/+page.svelte
+++ b/src/routes/room/[name]/game/+page.svelte
@@ -24,7 +24,7 @@
 	import VotingPanel from '$lib/components/ui/VotingPanel.svelte';
 	import VotingResultPanel from '$lib/components/ui/VotingResultPanel.svelte';
 
-	import type { ActionedPlayer, User } from '$lib/types/game';
+	import type { ActionedPlayer, PublishedVotingResult, User } from '$lib/types/game';
 
 	// Game state
 	const gameState = createGameState();
@@ -36,6 +36,7 @@
 		currentRound,
 		roundPhase,
 		isHost,
+		publishedVotingResult,
 		currentPlayerRole,
 		skillActions,
 		hasLoadedSkills,
@@ -67,6 +68,7 @@
 	let isIdentifying = $state(false);
 	let actionAreaElement: HTMLDivElement | null = $state(null);
 	let justUsedSkill = $state(false); // 防止使用技能後立即自動跳轉
+	let roundStatusRequestSequence = 0;
 
 	// roomName 需要立即從 URL 參數初始化
 	let roomName = $state($page.params.name || '');
@@ -167,15 +169,15 @@
 	async function fetchArtifacts() {
 		const artifacts = await gameService.fetchArtifacts();
 		if (artifacts.length > 0) {
-			// 對已鑑定的獸首，保留目前 store 中的 isGenuine 值，
-			// 避免伺服器回傳的原始值覆蓋交換後的鑑定結果
+			// 私人鑑定結果不屬於 artifacts API，刷新結構資料時保留在
+			// identifiedIsGenuine，避免與公開投票結果共用欄位。
 			const currentHeads = $beastHeads;
 			if (currentHeads.length > 0) {
 				for (const artifact of artifacts) {
 					if ($identifiedArtifacts.includes(artifact.id)) {
 						const existing = currentHeads.find((b) => b.id === artifact.id);
 						if (existing) {
-							artifact.isGenuine = existing.isGenuine;
+							artifact.identifiedIsGenuine = existing.identifiedIsGenuine;
 						}
 					}
 				}
@@ -246,14 +248,27 @@
 	}
 
 	async function fetchRoundStatus() {
+		const requestSequence = ++roundStatusRequestSequence;
 		// 如果遊戲已結束，不再更新狀態
 		if ($isGameFinished) return;
 
 		try {
 			const data = await gameService.fetchRoundStatus();
+			if (requestSequence !== roundStatusRequestSequence) return;
 			if (!data) {
 				console.warn('[fetchRoundStatus] API 返回空數據，跳過更新');
 				return;
+			}
+
+			// 公開結果必須先於 result phase 寫入，避免面板以舊資料渲染。
+			if (data.votingResult) {
+				publishedVotingResult.set(data.votingResult);
+			} else if (data.phase !== 'result') {
+				publishedVotingResult.set(null);
+			}
+
+			if (data.round) {
+				currentRound.set(data.round);
 			}
 
 			if (data.phase) {
@@ -271,6 +286,13 @@
 			console.error('[fetchRoundStatus] 獲取回合狀態失敗:', error);
 			// 不拋出錯誤，讓遊戲繼續載入
 		}
+	}
+
+	function applyPublishedVotingResult(result: PublishedVotingResult) {
+		if (result.round < $currentRound) return;
+		publishedVotingResult.set(result);
+		currentRound.set(result.round);
+		roundPhase.set('result');
 	}
 
 	async function fetchTeammateInfo() {
@@ -385,7 +407,7 @@
 									if (index !== -1) {
 										heads[index] = {
 											...heads[index],
-											isGenuine: identifyAction.data.result as boolean
+											identifiedIsGenuine: identifyAction.data.result as boolean
 										};
 									}
 									return [...heads];
@@ -491,7 +513,10 @@
 				beastHeads.update((heads) => {
 					const index = heads.findIndex((b) => b.id === beastId);
 					if (index !== -1 && data.result) {
-						heads[index] = { ...heads[index], isGenuine: data.result.isGenuine };
+						heads[index] = {
+							...heads[index],
+							identifiedIsGenuine: data.result.isGenuine
+						};
 					}
 					return [...heads];
 				});
@@ -933,20 +958,10 @@
 					console.log(`[socket] 加入房間: ${roomName}`);
 					socket.emit('join-room', roomName);
 
-					// 監聽連線事件
-					socket.on('connect', () => {
+					// connect 在首次連線與每次重連都會觸發。
+					socket.on('connect', async () => {
 						console.log('[socket] Socket 已連線');
-						// 重新加入房間
 						socket!.emit('join-room', roomName);
-					});
-
-					// 監聽重新連線事件
-					socket.on('reconnect', async () => {
-						console.log('[socket] Socket 重新連線成功，同步數據...');
-						// 重新加入房間
-						socket!.emit('join-room', roomName);
-
-						// 先獲取回合狀態檢查遊戲是否結束
 						await fetchRoundStatus();
 
 						// 如果遊戲已結束但還沒有最終結果，主動獲取
@@ -960,14 +975,9 @@
 							}
 						}
 
-						// 重新獲取其他數據
 						await fetchArtifacts();
 						await updatePlayersAndRound();
-
-						// 重新套用鑑定狀態，避免 fetchArtifacts 覆蓋交換後的鑑定結果
 						restoreIdentifiedState();
-
-						addNotification('連線已恢復', 'success', 2000);
 					});
 
 					// 監聽房間加入成功事件
@@ -988,16 +998,14 @@
 						console.log('[voting-completed] 收到投票完成事件:', data);
 						addNotification('投票結果已公布', 'info', 3000);
 
-						// Update phase to result
-						if (data.phase) {
-							console.log('[voting-completed] 更新階段為:', data.phase);
-							roundPhase.set(data.phase);
+						if (data.votingResult) {
+							applyPublishedVotingResult(data.votingResult);
 						}
 
 						// Refresh artifacts to get voting results
 						console.log('[voting-completed] 刷新獸首資料...');
-						await fetchArtifacts();
 						await fetchRoundStatus();
+						await fetchArtifacts();
 						console.log('[voting-completed] 數據刷新完成');
 					});
 
@@ -1329,14 +1337,17 @@
 								beastHeads={$beastHeads}
 								identifiedArtifacts={$identifiedArtifacts}
 								isHost={$isHost}
-								onVotesSubmitted={fetchArtifacts}
+								onVotesSubmitted={(result) => {
+									applyPublishedVotingResult(result);
+									void fetchArtifacts();
+								}}
 							/>
 						</div>
 					</div>
 				{:else if $roundPhase === 'result'}
 					<VotingResultPanel
 						{roomName}
-						beastHeads={$beastHeads}
+						votingResult={$publishedVotingResult}
 						isHost={$isHost}
 						currentRound={$currentRound}
 						onNextRound={async () => {


### PR DESCRIPTION
## 問題與推測原因

Issue #104 的現象是公布投票結果時，房主與其他玩家可能看到不同的前兩名、票數或第二名真偽。

推測原因有三個：

1. 房主提交投票後會立即取得較新的資料；其他玩家主要依賴一次性的 `voting-completed` Socket 事件。若事件漏接，原本的 HTTP 輪詢只更新 phase，沒有取得同一份公開投票結果。
2. 結果面板會從各玩家本機的 `beastHeads` 排序與推算結果，而這份資料可能有不同更新時序。
3. 私人鑑定與伺服器公開真實值共用 `isGenuine`。受「交換／迷惑」影響的個人鑑定值可能與公開真實值彼此覆蓋，造成第二名真偽因玩家而異。

另外，原本投票提交缺少完整的房主權限與並行提交保護，可能讓重複請求留下不一致狀態。

## 修改內容

- 新增共用 `PublishedVotingResult`，將公開投票結果與私人鑑定資料分離。
- 公開結果由伺服器依資料庫中的 `voteRank`、`votes`、`gameArtifacts.isGenuine` 建立，資料庫成為唯一權威來源。
- `submit-votes`：
  - 僅允許房主提交。
  - 在 transaction 中鎖定回合並驗證 `voting` phase。
  - 一次完成票數、名次與 `result` phase 更新。
  - 回應及 Socket 廣播統一使用 `votingResult`。
- `round-status` 在 `result` 階段回傳同一份 `votingResult`；資料不完整時回傳錯誤，不建立假結果。
- 前端以獨立的 `publishedVotingResult` state 顯示結果，不再從 `beastHeads` 本機推算。
- 私人鑑定改存於 `identifiedIsGenuine`，保留玩家各自的鑑定與 action log，不會覆蓋公開結果。
- Socket 作為即時通知；初次載入、每 3 秒輪詢、Socket connect／重連及頁面回到前景時，都會透過 `round-status` 恢復至權威狀態。
- 加入 request sequence，避免較舊的重疊請求覆蓋較新的 phase/result。
- 新回合會清除上一回合的公開結果。
- artifacts API 不再提前暴露伺服器真實值。
- 不需要資料庫 migration。

## 影響

- 公布後所有玩家會收斂到完全相同的前兩名、票數及第二名真偽。
- Socket 漏接或玩家暫時離線時，最遲會在下一次 3 秒輪詢恢復一致。
- 受迷惑玩家的私人鑑定結果仍保留，但不再影響公開結果。
- 第一名真偽仍維持待揭曉。

## 驗證

- TDD：公開結果 helper 先紅後綠，2 tests passed。
- 狀態測試：私人鑑定與公開結果分離、跨回合清除，2 tests passed。
- 完整 API tests：25 files / 250 tests passed。
- `npm run check`：0 errors / 0 warnings。
- `npm run lint`：passed。
- `npm run build`：passed（僅既有 Browserslist／PWA glob warning）。
- 8 人 E2E 第一回合已驗證房主與其餘 7 名玩家的結果卡完全一致；依要求跳過後續完整遊戲流程。
- pre-push 的 production build 通過；目前執行環境沒有 Docker，因此 Docker image hook 無法執行，改以 `--no-verify` 推送。

Closes #104