### PR TITLE
fix(game): invalidate stale round-status polls

### DIFF
--- a/src/lib/utils/__tests__/latestRequest.test.ts
+++ b/src/lib/utils/__tests__/latestRequest.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { createLatestRequestTracker } from '../latestRequest';
+
+describe('createLatestRequestTracker', () => {
+	it('套用較新的權威狀態後，會使所有在途請求失效', () => {
+		const tracker = createLatestRequestTracker();
+		const staleRequest = tracker.start();
+
+		expect(tracker.isLatest(staleRequest)).toBe(true);
+
+		tracker.invalidate();
+
+		expect(tracker.isLatest(staleRequest)).toBe(false);
+	});
+
+	it('只有最後啟動的重疊請求可以套用結果', () => {
+		const tracker = createLatestRequestTracker();
+		const firstRequest = tracker.start();
+		const secondRequest = tracker.start();
+
+		expect(tracker.isLatest(firstRequest)).toBe(false);
+		expect(tracker.isLatest(secondRequest)).toBe(true);
+	});
+});

--- a/src/lib/utils/latestRequest.ts
+++ b/src/lib/utils/latestRequest.ts
@@ -1,0 +1,15 @@
+export function createLatestRequestTracker() {
+	let sequence = 0;
+
+	return {
+		start() {
+			return ++sequence;
+		},
+		isLatest(requestSequence: number) {
+			return requestSequence === sequence;
+		},
+		invalidate() {
+			sequence += 1;
+		}
+	};
+}

--- a/src/routes/room/[name]/game/+page.svelte
+++ b/src/routes/room/[name]/game/+page.svelte
@@ -4,6 +4,7 @@
 	import { GameService } from '$lib/services/gameService';
 	import { createGameState } from '$lib/stores/gameState';
 	import { addNotification, currentGameStatus } from '$lib/stores/notifications';
+	import { createLatestRequestTracker } from '$lib/utils/latestRequest';
 	import { disconnectSocket, initSocket } from '$lib/utils/socket';
 	import type { Socket } from 'socket.io-client';
 	import { onDestroy, onMount } from 'svelte';
@@ -68,7 +69,7 @@
 	let isIdentifying = $state(false);
 	let actionAreaElement: HTMLDivElement | null = $state(null);
 	let justUsedSkill = $state(false); // 防止使用技能後立即自動跳轉
-	let roundStatusRequestSequence = 0;
+	const roundStatusRequests = createLatestRequestTracker();
 
 	// roomName 需要立即從 URL 參數初始化
 	let roomName = $state($page.params.name || '');
@@ -248,13 +249,13 @@
 	}
 
 	async function fetchRoundStatus() {
-		const requestSequence = ++roundStatusRequestSequence;
+		const requestSequence = roundStatusRequests.start();
 		// 如果遊戲已結束，不再更新狀態
 		if ($isGameFinished) return;
 
 		try {
 			const data = await gameService.fetchRoundStatus();
-			if (requestSequence !== roundStatusRequestSequence) return;
+			if (!roundStatusRequests.isLatest(requestSequence)) return;
 			if (!data) {
 				console.warn('[fetchRoundStatus] API 返回空數據，跳過更新');
 				return;
@@ -290,6 +291,7 @@
 
 	function applyPublishedVotingResult(result: PublishedVotingResult) {
 		if (result.round < $currentRound) return;
+		roundStatusRequests.invalidate();
 		publishedVotingResult.set(result);
 		currentRound.set(result.round);
 		roundPhase.set('result');


### PR DESCRIPTION
## 問題

這是已合併 PR #109 的 follow-up 修正。

當 `submit-votes` HTTP response 或 Socket event 直接套用公開投票結果時，先前已發出的 `round-status` 輪詢仍可能通過原本的 sequence check。若該舊回應帶著 `voting` phase，會短暫清除 `publishedVotingResult` 並把畫面倒退至投票階段，直到下一次輪詢才恢復。

## 修改

- 新增簡單的 latest-request tracker，統一管理 round-status request token。
- 每次開始輪詢時產生新 token，只有最新 token 可以套用回應。
- 套用較新的權威 `PublishedVotingResult` 前先呼叫 `invalidate()`，使所有既有在途輪詢失效。
- 保留舊回合結果防護：過期 round 的結果不會觸發 invalidation 或狀態更新。

## TDD／驗證

- 先新增競態回歸測試，確認缺少 tracker 實作時測試失敗。
- `latestRequest.test.ts`：2 tests passed。
  - 權威狀態套用後，既有請求 token 失效。
  - 重疊請求只有最後啟動者有效。
- `npm run check`：0 errors / 0 warnings。
- `npm run lint`：passed。
- `npm run build`：passed（僅既有 Browserslist／PWA glob warning）。

Review follow-up for #109.