### PR TITLE
fix(game): preserve turn order between rounds

### DIFF
--- a/src/lib/server/__tests__/game-round-start.test.ts
+++ b/src/lib/server/__tests__/game-round-start.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { gameActions, gameRounds, games } from '../db/schema';
+
+const { dbMock } = vi.hoisted(() => ({
+	dbMock: {
+		select: vi.fn(),
+		insert: vi.fn()
+	}
+}));
+
+vi.mock('../db', () => ({ db: dbMock }));
+
+import { startNewRound } from '../game';
+
+describe('startNewRound', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('uses the previous turn order even when the last player skipped their skill', async () => {
+		let roundReadCount = 0;
+		let insertedRound: Record<string, unknown> | undefined;
+
+		dbMock.select.mockImplementation(() => ({
+			from: (table: unknown) => {
+				const rows =
+					table === gameRounds
+						? ++roundReadCount === 1
+							? [
+									{
+										id: 509,
+										gameId: 'game-1',
+										round: 2,
+										completedAt: new Date(),
+										actionOrder: [1556, 1557, 1561, 1559, 1555, 1558, 1560]
+									}
+								]
+							: []
+						: table === gameActions
+							? [{ playerId: 1557, ordering: 10 }]
+							: table === games
+								? []
+								: [];
+
+				return {
+					where: () => ({
+						limit: async () => rows,
+						orderBy: async () => rows
+					})
+				};
+			}
+		}));
+		dbMock.insert.mockImplementation(() => ({
+			values: (values: Record<string, unknown>) => ({
+				returning: async () => {
+					insertedRound = values;
+					return [{ id: 510, ...values }];
+				}
+			})
+		}));
+
+		const result = await startNewRound('game-1', 3);
+
+		expect(result.firstPlayerId).toBe(1556);
+		expect(insertedRound).toMatchObject({ round: 3, actionOrder: [1556] });
+	});
+});

--- a/src/lib/server/__tests__/game-turn-order.test.ts
+++ b/src/lib/server/__tests__/game-turn-order.test.ts
@@ -1,7 +1,23 @@
 import { describe, expect, it } from 'vitest';
-import { getAttackedRound, hasPlayerTakenTurn } from '../game-turn-order';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { getAttackedRound, getNextRoundStarter, hasPlayerTakenTurn } from '../game-turn-order';
 
 describe('game turn order', () => {
+	it('uses the last player in turn order as the next round starter', () => {
+		expect(getNextRoundStarter([1556, 1557, 1561, 1559, 1555, 1558, 1560])).toBe(1556);
+	});
+
+	it('manual round start uses turn order instead of skill actions', () => {
+		const source = readFileSync(
+			resolve(process.cwd(), 'src/routes/api/room/[name]/start/+server.ts'),
+			'utf8'
+		);
+
+		expect(source).toContain('getNextRoundStarter(previousRound.actionOrder)');
+		expect(source).not.toContain('.from(gameActions)');
+	});
+
 	it('treats a player in actionOrder as having taken a turn even without an action record', () => {
 		const actionOrder = [1461, 1459, 1458, 1460, 1464, 1463, 1465];
 

--- a/src/lib/server/game-turn-order.ts
+++ b/src/lib/server/game-turn-order.ts
@@ -3,6 +3,13 @@
  * their turn remain behind the current player, even when they performed no
  * action and therefore have no gameActions row.
  */
+export function getNextRoundStarter(actionOrder: unknown): number | null {
+	if (!Array.isArray(actionOrder) || actionOrder.length === 0) return null;
+
+	const playerId = Number(actionOrder[0]);
+	return Number.isInteger(playerId) ? playerId : null;
+}
+
 export function hasPlayerTakenTurn(actionOrder: unknown, playerId: number): boolean {
 	if (!Array.isArray(actionOrder)) return false;
 

--- a/src/lib/server/game.ts
+++ b/src/lib/server/game.ts
@@ -9,6 +9,7 @@ import {
 	gameActions
 } from './db/schema';
 import { eq, and, sql } from 'drizzle-orm';
+import { getNextRoundStarter } from './game-turn-order';
 
 // 遊戲角色配置
 export const GAME_ROLES = {
@@ -670,22 +671,10 @@ export async function startNewRound(gameId: string, roundNumber: number) {
 		throw new Error(`第 ${roundNumber} 回合已存在`);
 	}
 
-	// 獲取上一回合最後一個行動的玩家
-	const lastActions = await db
-		.select({
-			playerId: gameActions.playerId,
-			ordering: gameActions.ordering
-		})
-		.from(gameActions)
-		.where(and(eq(gameActions.gameId, gameId), eq(gameActions.roundId, previousRound.id)))
-		.orderBy(gameActions.ordering);
-
-	if (lastActions.length === 0) {
-		throw new Error('上一回合沒有任何玩家行動記錄');
+	const lastPlayerId = getNextRoundStarter(previousRound.actionOrder);
+	if (lastPlayerId === null) {
+		throw new Error('上一回合沒有有效的行動順序');
 	}
-
-	// 最後一個行動的玩家
-	const lastPlayerId = lastActions[lastActions.length - 1].playerId;
 
 	// 創建新回合，並將上一回合最後一位玩家設為第一位
 	const [newRound] = await db

--- a/src/routes/api/room/[name]/start/+server.ts
+++ b/src/routes/api/room/[name]/start/+server.ts
@@ -3,7 +3,8 @@ import type { RequestHandler } from './$types';
 import { startGame, startRoleSelection } from '$lib/server/game';
 import { verifyHostPermission } from '$lib/server/api-helpers';
 import { db } from '$lib/server/db';
-import { gamePlayers, gameRounds, gameActions, roles } from '$lib/server/db/schema';
+import { gamePlayers, gameRounds, roles } from '$lib/server/db/schema';
+import { getNextRoundStarter } from '$lib/server/game-turn-order';
 import { eq, and } from 'drizzle-orm';
 import { chineseNumeral } from '$lib/utils/round';
 
@@ -255,24 +256,12 @@ export const POST: RequestHandler = async (event) => {
 				return json({ message: `第 ${nextRoundNumber} 回合已經存在` }, { status: 400 });
 			}
 
-			// 獲取上一回合的最後一個行動玩家
-			const lastActions = await db
-				.select({
-					playerId: gameActions.playerId,
-					ordering: gameActions.ordering
-				})
-				.from(gameActions)
-				.where(and(eq(gameActions.gameId, game.id), eq(gameActions.roundId, previousRound.id)))
-				.orderBy(gameActions.ordering);
-
-			if (lastActions.length === 0) {
-				return json({ message: '上一回合沒有任何玩家行動記錄' }, { status: 400 });
+			const lastPlayerId = getNextRoundStarter(previousRound.actionOrder);
+			if (lastPlayerId === null) {
+				return json({ message: '上一回合沒有有效的行動順序' }, { status: 400 });
 			}
 
-			// 獲取最後一個行動的玩家
-			const lastPlayerId = lastActions[lastActions.length - 1].playerId;
-
-			// 創建新回合，最後行動的玩家成為新回合的起始玩家
+			// 創建新回合，上一回合最後輪到的玩家成為新回合的起始玩家
 			const [newRound] = await db
 				.insert(gameRounds)
 				.values({


### PR DESCRIPTION
## 變更內容

- 下一回合起始玩家改由上一回合完成後的 `actionOrder[0]` 決定
- 自動換回合與房主手動 `/start` 路徑共用相同判斷方式
- 第一回合仍維持隨機選擇起始玩家
- 新增「最後輪到的玩家未使用技能」回歸測試

## 根本原因

原本建立第二、三回合時會查詢 `game_actions` 的最後一筆技能紀錄，誤把「最後使用技能的玩家」當成「上一回合最後輪到的玩家」。當最後輪到的玩家跳過技能時，下一回合便會從錯誤玩家開始。

## 影響

換回合現在只依據已完成的玩家輪替順序，不再受到玩家是否使用技能影響。

## 驗證

- Unit：52 passed
- API：269 passed
- 8 人完整三輪、鑑人及最終結果 E2E：1 passed（12 秒）
- Prettier / ESLint：通過
- Svelte check：0 errors、0 warnings
- Production build：通過
- Docker image build：通過